### PR TITLE
Fixed appending of validation errors

### DIFF
--- a/api/appconfig.go
+++ b/api/appconfig.go
@@ -2,11 +2,11 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
 	"github.com/golang/glog"
-	"net/http"
-	"gopkg.in/yaml.v2"
 	"github.com/imdario/mergo"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"net/http"
 	"strconv"
 )
 
@@ -141,62 +141,70 @@ func validateAppConfig(appConfig NaisAppConfig) ValidationErrors {
 
 	var validationErrors ValidationErrors
 
-	validationErrors = validateReplicasMax(appConfig)
+	if error := validateReplicasMax(appConfig); error != nil {
+		validationErrors.Errors = append(validationErrors.Errors, *error)
+	}
 
-	validationErrors = validateReplicasMin(appConfig)
+	if error := validateReplicasMin(appConfig); error != nil {
+		validationErrors.Errors = append(validationErrors.Errors, *error)
+	}
 
-	validationErrors = validateMinIsSmallerThanMax(appConfig)
+	if error := validateMinIsSmallerThanMax(appConfig); error != nil {
+		validationErrors.Errors = append(validationErrors.Errors, *error)
+	}
 
-	validationErrors = validateCpuThreshold(appConfig)
+	if error := validateCpuThreshold(appConfig); error != nil {
+		validationErrors.Errors = append(validationErrors.Errors, *error)
+	}
 
 	return validationErrors
 }
-func validateCpuThreshold(appConfig NaisAppConfig) (validationErrors ValidationErrors) {
+
+func validateCpuThreshold(appConfig NaisAppConfig) *ValidationError {
 	if appConfig.Replicas.CpuThresholdPercentage < 10 || appConfig.Replicas.CpuThresholdPercentage > 90 {
 		error := new(ValidationError)
 		error.ErrorMessage = "CpuThreshold must be between 10 and 90."
 		error.Fields = make(map[string]string)
 		error.Fields["Replicas.CpuThreshold"] = strconv.Itoa(appConfig.Replicas.CpuThresholdPercentage)
-		validationErrors.Errors = append(validationErrors.Errors, *error)
+		return error
 
 	}
-	return validationErrors
+	return nil
 
 }
-func validateMinIsSmallerThanMax(appConfig NaisAppConfig) (validationErrors ValidationErrors) {
+func validateMinIsSmallerThanMax(appConfig NaisAppConfig) *ValidationError {
 	if appConfig.Replicas.Min > appConfig.Replicas.Max {
 		validationError := new(ValidationError)
 		validationError.ErrorMessage = "Replicas.Min is larger than Replicas.Max."
 		validationError.Fields = make(map[string]string)
 		validationError.Fields["Replicas.Max"] = strconv.Itoa(appConfig.Replicas.Max)
 		validationError.Fields["Replicas.Min"] = strconv.Itoa(appConfig.Replicas.Min)
-		validationErrors.Errors = append(validationErrors.Errors, *validationError)
+		return validationError
 	}
-	return validationErrors
+	return nil
 
 }
-func validateReplicasMin(appConfig NaisAppConfig) (validationErrors ValidationErrors) {
+func validateReplicasMin(appConfig NaisAppConfig) *ValidationError {
 	if appConfig.Replicas.Min == 0 {
 		validationError := new(ValidationError)
 		validationError.ErrorMessage = "Replicas.Min is not set"
 		validationError.Fields = make(map[string]string)
 		validationError.Fields["Replicas.Min"] = strconv.Itoa(appConfig.Replicas.Min)
-		validationErrors.Errors = append(validationErrors.Errors, *validationError)
+		return validationError
 
 	}
-	return validationErrors
+	return nil
 
 }
-func validateReplicasMax(appConfig NaisAppConfig) (validationErrors ValidationErrors) {
+func validateReplicasMax(appConfig NaisAppConfig) *ValidationError {
 	if appConfig.Replicas.Max == 0 {
 		validationError := new(ValidationError)
 		validationError.ErrorMessage = "Replicas.Max is not set"
 		validationError.Fields = make(map[string]string)
 		validationError.Fields["Replicas.Max"] = strconv.Itoa(appConfig.Replicas.Max)
-		validationErrors.Errors = append(validationErrors.Errors, *validationError)
-
+		return validationError
 	}
-	return validationErrors
+	return nil
 
 }
 

--- a/api/appconfig_test.go
+++ b/api/appconfig_test.go
@@ -101,6 +101,21 @@ func TestInvalidReplicasConfigGivesValidationErrors(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMultipleInvalidAppConfigFields(t *testing.T) {
+	invalidConfig := NaisAppConfig{
+		Replicas: Replicas{
+			CpuThresholdPercentage: 5,
+			Max: 4,
+			Min: 5,
+		},
+	}
+	errors := validateAppConfig(invalidConfig)
+
+	assert.Equal(t, 2, len(errors.Errors))
+	assert.Equal(t, "Replicas.Min is larger than Replicas.Max.", errors.Errors[0].ErrorMessage)
+	assert.Equal(t, "CpuThreshold must be between 10 and 90.", errors.Errors[1].ErrorMessage)
+}
+
 func TestInvalidCpuThreshold(t *testing.T) {
 	invalidConfig := NaisAppConfig{
 		Replicas: Replicas{

--- a/api/appconfig_test.go
+++ b/api/appconfig_test.go
@@ -1,9 +1,9 @@
 package api
 
 import (
-	"testing"
-	"gopkg.in/h2non/gock.v1"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+	"testing"
 )
 
 func TestAppConfigUnmarshal(t *testing.T) {
@@ -105,24 +105,24 @@ func TestInvalidCpuThreshold(t *testing.T) {
 	invalidConfig := NaisAppConfig{
 		Replicas: Replicas{
 			CpuThresholdPercentage: 5,
-			Max:                    4,
-			Min:                    5,
+			Max: 4,
+			Min: 5,
 		},
 	}
 	errors := validateCpuThreshold(invalidConfig)
 	t.Log(errors)
 
-	assert.Equal(t, 1, len(errors.Errors))
+	assert.Equal(t, "CpuThreshold must be between 10 and 90.", errors.ErrorMessage)
 }
 func TestMinCannotBeZero(t *testing.T) {
 	invalidConfig := NaisAppConfig{
 		Replicas: Replicas{
 			CpuThresholdPercentage: 50,
-			Max:                    4,
-			Min:                    0,
+			Max: 4,
+			Min: 0,
 		},
 	}
 	errors := validateReplicasMin(invalidConfig)
 
-	assert.Equal(t, 1, len(errors.Errors))
+	assert.Equal(t, "Replicas.Min is not set", errors.ErrorMessage)
 }

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -2,16 +2,16 @@ package api
 
 import (
 	"fmt"
-	"strings"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/errors"
 	k8sresource "k8s.io/client-go/pkg/api/resource"
 	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 	autoscalingv1 "k8s.io/client-go/pkg/apis/autoscaling/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/errors"
 	"strconv"
+	"strings"
 )
 
 type DeploymentResult struct {


### PR DESCRIPTION
Every validation check returns a new slice of ValidationError, so each call overwrites the previous one.

Format changes are due to `gofmt`, sorry about that…