### PR TITLE
Fix #40 by setting individual env vars from applicationProperties

### DIFF
--- a/api/fasit.go
+++ b/api/fasit.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 func init() {
@@ -143,6 +144,12 @@ func (fasit FasitClient) mapToNaisResource(fasitResource FasitResource) (resourc
 
 		resource.certificates = files
 
+	} else if fasitResource.ResourceType == "applicationproperties" {
+		for _, prop := range strings.Split(fasitResource.Properties["applicationProperties"], "\r\n") {
+			parts := strings.SplitN(prop, "=", 2)
+			resource.properties[parts[0]] = parts[1]
+		}
+		delete(resource.properties, "applicationProperties")
 	}
 
 	return resource, nil

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -53,6 +53,10 @@ func createServiceDef(application, namespace string) *v1.Service {
 }
 
 func ResourceVariableName(resource NaisResource, key string) string {
+	if resource.resourceType == "applicationproperties" {
+		return key
+	}
+
 	if strings.Contains(resource.name, ".") {
 		return strings.Replace(resource.name, ".", "_", -1) + "_" + key
 	}
@@ -103,8 +107,8 @@ func createDeploymentDef(naisResources []NaisResource, appConfig NaisAppConfig, 
 						},
 					},
 				},
-				ProgressDeadlineSeconds:int32p(600),
-				RevisionHistoryLimit: int32p(10),
+				ProgressDeadlineSeconds: int32p(600),
+				RevisionHistoryLimit:    int32p(10),
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: createOjectMeta(deploymentRequest, appConfig),
 					Spec:       createPodSpec(deploymentRequest, appConfig, naisResources),

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -53,17 +53,20 @@ func createServiceDef(application, namespace string) *v1.Service {
 }
 
 func ResourceVariableName(resource NaisResource, key string) string {
+	name := resource.name + "_" + key
+
 	if resource.resourceType == "applicationproperties" {
-		return key
+		name = key
 	}
 
-	if strings.Contains(resource.name, ".") {
-		return strings.Replace(resource.name, ".", "_", -1) + "_" + key
+	if strings.Contains(name, ".") {
+		return strings.Replace(name, ".", "_", -1)
 	}
-	if strings.Contains(resource.name, ":") {
-		return strings.Replace(resource.name, ":", "_", -1) + "_" + key
+
+	if strings.Contains(name, ":") {
+		return strings.Replace(name, ":", "_", -1)
 	}
-	return resource.name + "_" + key
+	return name
 }
 
 func ResourceEnvironmentVariableName(resource NaisResource, key string) string {

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -159,8 +159,8 @@ func TestDeployment(t *testing.T) {
 			"resource3",
 			"applicationproperties",
 			map[string]string{
-				"key1": "value1",
-				"key2": "dc=preprod,dc=local",
+				"key1":          "value1",
+				"key2.property": "dc=preprod,dc=local",
 			},
 			map[string]string{},
 			nil,
@@ -262,8 +262,8 @@ func TestDeployment(t *testing.T) {
 		assert.Equal(t, "key1", env[10].Name)
 		assert.Equal(t, "KEY1", env[11].Name)
 
-		assert.Equal(t, "key2", env[12].Name)
-		assert.Equal(t, "KEY2", env[13].Name)
+		assert.Equal(t, "key2_property", env[12].Name)
+		assert.Equal(t, "KEY2_PROPERTY", env[13].Name)
 
 		assert.Equal(t, "dots_are_not_allowed_key", env[14].Name)
 		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_KEY", env[15].Name)

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -159,8 +159,16 @@ func TestDeployment(t *testing.T) {
 			"resource3",
 			"applicationproperties",
 			map[string]string{
-				"key1":          "value1",
-				"key2.property": "dc=preprod,dc=local",
+				"key1": "value1",
+			},
+			map[string]string{},
+			nil,
+		},
+		{
+			"resource4",
+			"applicationproperties",
+			map[string]string{
+				"key2.Property": "dc=preprod,dc=local",
 			},
 			map[string]string{},
 			nil,
@@ -262,7 +270,7 @@ func TestDeployment(t *testing.T) {
 		assert.Equal(t, "key1", env[10].Name)
 		assert.Equal(t, "KEY1", env[11].Name)
 
-		assert.Equal(t, "key2_property", env[12].Name)
+		assert.Equal(t, "key2_Property", env[12].Name)
 		assert.Equal(t, "KEY2_PROPERTY", env[13].Name)
 
 		assert.Equal(t, "dots_are_not_allowed_key", env[14].Name)

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -2,12 +2,12 @@ package api
 
 import (
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/pkg/util/intstr"
-	"testing"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/resource"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/intstr"
 	"strings"
+	"testing"
 )
 
 const (
@@ -156,6 +156,16 @@ func TestDeployment(t *testing.T) {
 			map[string][]byte{cert2Key: cert2Value},
 		},
 		{
+			"resource3",
+			"applicationproperties",
+			map[string]string{
+				"key1": "value1",
+				"key2": "dc=preprod,dc=local",
+			},
+			map[string]string{},
+			nil,
+		},
+		{
 			invalidlyNamedResourceNameDot,
 			invalidlyNamedResourceTypeDot,
 			map[string]string{invalidlyNamedResourceKeyDot: invalidlyNamedResourceValueDot},
@@ -223,7 +233,7 @@ func TestDeployment(t *testing.T) {
 		}, deployment.Spec.Template.Annotations)
 
 		env := container.Env
-		assert.Equal(t, 18, len(env))
+		assert.Equal(t, 22, len(env))
 		assert.Equal(t, "app_version", env[0].Name)
 		assert.Equal(t, version, env[0].Value)
 		assert.Equal(t, "APP_VERSION", env[1].Name)
@@ -249,21 +259,27 @@ func TestDeployment(t *testing.T) {
 		assert.Equal(t, strings.ToUpper(resource2Name+"_"+secret2Key), env[9].Name)
 		assert.Equal(t, createSecretRef(otherAppName, secret2Key, resource2Name), env[9].ValueFrom)
 
-		assert.Equal(t, "dots_are_not_allowed_key", env[10].Name)
-		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_KEY", env[11].Name)
+		assert.Equal(t, "key1", env[10].Name)
+		assert.Equal(t, "KEY1", env[11].Name)
 
-		assert.Equal(t, "dots_are_not_allowed_secretkey", env[12].Name)
-		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_SECRETKEY", env[13].Name)
+		assert.Equal(t, "key2", env[12].Name)
+		assert.Equal(t, "KEY2", env[13].Name)
 
-		assert.Equal(t, "colon_are_not_allowed_key", env[14].Name)
-		assert.Equal(t, "COLON_ARE_NOT_ALLOWED_KEY", env[15].Name)
+		assert.Equal(t, "dots_are_not_allowed_key", env[14].Name)
+		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_KEY", env[15].Name)
 
-		assert.Equal(t, "colon_are_not_allowed_secretkey", env[16].Name)
-		assert.Equal(t, "COLON_ARE_NOT_ALLOWED_SECRETKEY", env[17].Name)
+		assert.Equal(t, "dots_are_not_allowed_secretkey", env[16].Name)
+		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_SECRETKEY", env[17].Name)
+
+		assert.Equal(t, "colon_are_not_allowed_key", env[18].Name)
+		assert.Equal(t, "COLON_ARE_NOT_ALLOWED_KEY", env[19].Name)
+
+		assert.Equal(t, "colon_are_not_allowed_secretkey", env[20].Name)
+		assert.Equal(t, "COLON_ARE_NOT_ALLOWED_SECRETKEY", env[21].Name)
 	})
 
 	t.Run("when a deployment exists, its updated", func(t *testing.T) {
-		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: newVersion,}, newDefaultAppConfig(), naisResources, clientset)
+		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: newVersion}, newDefaultAppConfig(), naisResources, clientset)
 		assert.NoError(t, err)
 
 		assert.Equal(t, resourceVersion, deployment.ObjectMeta.ResourceVersion)
@@ -281,7 +297,7 @@ func TestDeployment(t *testing.T) {
 		appConfig.Prometheus.Path = "/newPath"
 		appConfig.Prometheus.Enabled = false
 
-		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version,}, appConfig, naisResources, clientset)
+		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, appConfig, naisResources, clientset)
 		assert.NoError(t, err)
 
 		assert.Equal(t, map[string]string{
@@ -306,7 +322,7 @@ func TestDeployment(t *testing.T) {
 			},
 		}
 
-		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version,}, newDefaultAppConfig(), updatedResource, clientset)
+		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, newDefaultAppConfig(), updatedResource, clientset)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 1, len(updatedDeployment.Spec.Template.Spec.Volumes))
@@ -320,7 +336,7 @@ func TestDeployment(t *testing.T) {
 	})
 
 	t.Run("File secrets are mounted correctly for a new deployment", func(t *testing.T) {
-		deployment, _ := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version,}, newDefaultAppConfig(), naisResources, clientset)
+		deployment, _ := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, newDefaultAppConfig(), naisResources, clientset)
 
 		assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Volumes))
 		assert.Equal(t, appName, deployment.Spec.Template.Spec.Volumes[0].Name)
@@ -347,13 +363,13 @@ func TestDeployment(t *testing.T) {
 			},
 		}
 
-		deployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version,}, newDefaultAppConfig(), resources, clientset)
+		deployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, newDefaultAppConfig(), resources, clientset)
 
 		assert.NoError(t, err)
 
 		spec := deployment.Spec.Template.Spec
-		assert.Empty(t, spec.Volumes,"Unexpected volumes")
-		assert.Empty(t, spec.Containers[0].VolumeMounts,"Unexpected volume mounts.")
+		assert.Empty(t, spec.Volumes, "Unexpected volumes")
+		assert.Empty(t, spec.Containers[0].VolumeMounts, "Unexpected volume mounts.")
 
 	})
 }
@@ -392,7 +408,7 @@ func TestIngress(t *testing.T) {
 		namespace := "nondefault"
 		ingress, err := createIngress(NaisDeploymentRequest{Namespace: namespace, Application: otherAppName}, subDomain, clientset)
 		assert.NoError(t, err)
-		assert.Equal(t, otherAppName+"-" +namespace+ "."+subDomain, ingress.Spec.Rules[0].Host)
+		assert.Equal(t, otherAppName+"-"+namespace+"."+subDomain, ingress.Spec.Rules[0].Host)
 	})
 
 	t.Run("when an ingress exists, nothing happens", func(t *testing.T) {

--- a/api/testdata/fasitResponse4.json
+++ b/api/testdata/fasitResponse4.json
@@ -1,0 +1,28 @@
+{
+  "type": "applicationproperties",
+  "alias": "alias4",
+  "scope": {
+    "environmentclass": "t",
+    "zone": "fss",
+    "application": "myapp"
+  },
+  "properties": {
+    "applicationProperties": "key1=value1\r\nkey2=dc=preprod,dc=local"
+  },
+  "secrets": {},
+  "files": {},
+  "dodgy": false,
+  "id": 3202414,
+  "revision": 3202415,
+  "created": "2017-09-26T16:09:43.186",
+  "updated": "2017-09-26T16:09:43.186",
+  "lifecycle": {},
+  "accesscontrol": {
+    "environmentclass": "t",
+    "adgroups": []
+  },
+  "links": {
+    "self": "https://fasit.adeo.no/api/v2/resources/3202414",
+    "revisions": "https://fasit.adeo.no/api/v2/resources/3202414/revisions"
+  }
+}


### PR DESCRIPTION
Changes:

* Deletes the original `applicationProperties`
* The env vars is **not** prefixed with resource name