### PR TITLE
Removal of lowercased env vars

### DIFF
--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -235,39 +235,24 @@ func createEnvironmentVariables(deploymentRequest NaisDeploymentRequest, naisRes
 	envVars := createDefaultEnvironmentVariables(deploymentRequest.Version)
 
 	for _, res := range naisResources {
-		for k, v := range res.properties {
-			for _, variableName := range [2]string{ResourceVariableName(res, k), ResourceEnvironmentVariableName(res, k)} {
-				envVar := v1.EnvVar{variableName, v, nil}
-				envVars = append(envVars, envVar)
-			}
+		for variableName, v := range res.properties {
+			envVar := v1.EnvVar{ResourceEnvironmentVariableName(res, variableName), v, nil}
+			envVars = append(envVars, envVar)
 		}
 		if res.secret != nil {
 			for k := range res.secret {
-				variableName := ResourceVariableName(res, k)
 				envVar := v1.EnvVar{
-					Name: variableName,
+					Name: ResourceEnvironmentVariableName(res, k),
 					ValueFrom: &v1.EnvVarSource{
 						SecretKeyRef: &v1.SecretKeySelector{
 							LocalObjectReference: v1.LocalObjectReference{
 								Name: deploymentRequest.Application,
 							},
-							Key: variableName,
-						},
-					},
-				}
-				envarUpper := v1.EnvVar{
-					Name: strings.ToUpper(variableName),
-					ValueFrom: &v1.EnvVarSource{
-						SecretKeyRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: deploymentRequest.Application,
-							},
-							Key: variableName,
+							Key: ResourceVariableName(res, k),
 						},
 					},
 				}
 				envVars = append(envVars, envVar)
-				envVars = append(envVars, envarUpper)
 			}
 		}
 	}
@@ -276,9 +261,6 @@ func createEnvironmentVariables(deploymentRequest NaisDeploymentRequest, naisRes
 
 func createDefaultEnvironmentVariables(version string) []v1.EnvVar {
 	return []v1.EnvVar{{
-		Name:  "app_version",
-		Value: version,
-	}, {
 		Name:  "APP_VERSION",
 		Value: version,
 	}}

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -241,49 +241,28 @@ func TestDeployment(t *testing.T) {
 		}, deployment.Spec.Template.Annotations)
 
 		env := container.Env
-		assert.Equal(t, 22, len(env))
-		assert.Equal(t, "app_version", env[0].Name)
+		assert.Equal(t, 11, len(env))
+		assert.Equal(t, "APP_VERSION", env[0].Name)
 		assert.Equal(t, version, env[0].Value)
-		assert.Equal(t, "APP_VERSION", env[1].Name)
-		assert.Equal(t, version, env[1].Value)
 
-		assert.Equal(t, resource1Name+"_"+resource1Key, env[2].Name)
-		assert.Equal(t, "value1", env[2].Value)
-		assert.Equal(t, strings.ToUpper(resource1Name+"_"+resource1Key), env[3].Name)
-		assert.Equal(t, "value1", env[3].Value)
+		assert.Equal(t, strings.ToUpper(resource1Name+"_"+resource1Key), env[1].Name)
+		assert.Equal(t, "value1", env[1].Value)
 
-		assert.Equal(t, resource1Name+"_"+secret1Key, env[4].Name)
-		assert.Equal(t, createSecretRef(otherAppName, secret1Key, resource1Name), env[4].ValueFrom)
-		assert.Equal(t, strings.ToUpper(resource1Name+"_"+secret1Key), env[5].Name)
-		assert.Equal(t, createSecretRef(otherAppName, secret1Key, resource1Name), env[5].ValueFrom)
+		assert.Equal(t, strings.ToUpper(resource1Name+"_"+secret1Key), env[2].Name)
+		assert.Equal(t, createSecretRef(otherAppName, secret1Key, resource1Name), env[2].ValueFrom)
 
-		assert.Equal(t, resource2Name+"_"+resource2Key, env[6].Name)
-		assert.Equal(t, "value2", env[6].Value)
-		assert.Equal(t, strings.ToUpper(resource2Name+"_"+resource2Key), env[7].Name)
-		assert.Equal(t, "value2", env[7].Value)
+		assert.Equal(t, strings.ToUpper(resource2Name+"_"+resource2Key), env[3].Name)
+		assert.Equal(t, "value2", env[3].Value)
 
-		assert.Equal(t, resource2Name+"_"+secret2Key, env[8].Name)
-		assert.Equal(t, createSecretRef(otherAppName, secret2Key, resource2Name), env[8].ValueFrom)
-		assert.Equal(t, strings.ToUpper(resource2Name+"_"+secret2Key), env[9].Name)
-		assert.Equal(t, createSecretRef(otherAppName, secret2Key, resource2Name), env[9].ValueFrom)
+		assert.Equal(t, strings.ToUpper(resource2Name+"_"+secret2Key), env[4].Name)
+		assert.Equal(t, createSecretRef(otherAppName, secret2Key, resource2Name), env[4].ValueFrom)
 
-		assert.Equal(t, "key1", env[10].Name)
-		assert.Equal(t, "KEY1", env[11].Name)
-
-		assert.Equal(t, "key2_Property", env[12].Name)
-		assert.Equal(t, "KEY2_PROPERTY", env[13].Name)
-
-		assert.Equal(t, "dots_are_not_allowed_key", env[14].Name)
-		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_KEY", env[15].Name)
-
-		assert.Equal(t, "dots_are_not_allowed_secretkey", env[16].Name)
-		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_SECRETKEY", env[17].Name)
-
-		assert.Equal(t, "colon_are_not_allowed_key", env[18].Name)
-		assert.Equal(t, "COLON_ARE_NOT_ALLOWED_KEY", env[19].Name)
-
-		assert.Equal(t, "colon_are_not_allowed_secretkey", env[20].Name)
-		assert.Equal(t, "COLON_ARE_NOT_ALLOWED_SECRETKEY", env[21].Name)
+		assert.Equal(t, "KEY1", env[5].Name)
+		assert.Equal(t, "KEY2_PROPERTY", env[6].Name)
+		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_KEY", env[7].Name)
+		assert.Equal(t, "DOTS_ARE_NOT_ALLOWED_SECRETKEY", env[8].Name)
+		assert.Equal(t, "COLON_ARE_NOT_ALLOWED_KEY", env[9].Name)
+		assert.Equal(t, "COLON_ARE_NOT_ALLOWED_SECRETKEY", env[10].Name)
 	})
 
 	t.Run("when a deployment exists, its updated", func(t *testing.T) {


### PR DESCRIPTION
After merge of #29 there's no need for the same lowercased environment variables.
The rationale behind this is that applications that expect a Java property on the form `my.property` will still work with the uppercased env var `MY_PROPERTY` (without any code changes in the app).
If the app wants to use the lowercased `my_property` then a code change has to be made.

Also there's now a little confusion about which env vars to use: the uppercased ones or the lowercased ones.