### PR TITLE
Feature/deployment status endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -67,7 +67,7 @@ func (api Api) NewApi() http.Handler {
 	mux.Handle(pat.Get("/isalive"), appHandler(api.isAlive))
 	mux.Handle(pat.Post("/deploy"), appHandler(api.deploy))
 	mux.Handle(pat.Get("/metrics"), promhttp.Handler())
-
+	mux.Handle(pat.Get("/deploystatus"), deploymentStatusHandler(api.Clientset))
 	return mux
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -100,11 +100,11 @@ func (api Api) deploymentStatusHandler(w http.ResponseWriter, r *http.Request) *
 		w.WriteHeader(http.StatusOK)
 	}
 
-	b, err := json.Marshal(view)
-	if err != nil {
-		return &appError{err, fmt.Sprintf("Unable to marshal deploy status view: %+v", view), http.StatusNotFound}
+	if b, err := json.Marshal(view); err == nil {
+		w.Write(b)
+	} else {
+		glog.Errorf("Unable to marshal deploy status view: %+v", view)
 	}
-	w.Write(b)
 
 	return nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -78,7 +78,7 @@ func TestValidDeploymentRequestAndAppConfigCreateResources(t *testing.T) {
 
 	clientset := fake.NewSimpleClientset()
 
-	api := Api{clientset, "https://fasit.local", "nais.example.tk"}
+	api := Api{clientset, "https://fasit.local", "nais.example.tk", nil}
 
 	depReq := NaisDeploymentRequest{
 		Application:  appName,

--- a/api/deploymentstatus.go
+++ b/api/deploymentstatus.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"k8s.io/client-go/kubernetes"
+	"path"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"fmt"
+)
+
+func deploymentStatusHandler(clientset kubernetes.Interface) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		namespace, appName := parseURLPath(r.URL)
+		if dep, err := clientset.ExtensionsV1beta1().Deployments(namespace).Get(appName); err != nil {
+			_, deployFinished, err := status(dep)
+
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if deployFinished {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusAccepted)
+			}
+
+		}
+
+	})
+
+}
+func status(deployment *v1beta1.Deployment) (string, bool, error) {
+	if deployment.Generation <= deployment.Status.ObservedGeneration {
+		if deploymentExceededProgressDeadline(deployment.Status) {
+			return "", false, fmt.Errorf("deployment %q exceeded its progress deadline", deployment.Name)
+		}
+		if deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
+			return fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas have been updated...\n", deployment.Status.UpdatedReplicas, deployment.Spec.Replicas), false, nil
+		}
+		if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
+			return fmt.Sprintf("Waiting for rollout to finish: %d old replicas are pending termination...\n", deployment.Status.Replicas-deployment.Status.UpdatedReplicas), false, nil
+		}
+		if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
+			return fmt.Sprintf("Waiting for rollout to finish: %d of %d updated replicas are available...\n", deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas), false, nil
+		}
+		return fmt.Sprintf("deployment %q successfully rolled out\n", deployment.Name), true, nil
+	}
+}
+func deploymentExceededProgressDeadline(status v1beta1.DeploymentStatus) bool {
+	for i := range status.Conditions {
+		c := status.Conditions[i]
+		if c.Type == v1beta1.DeploymentProgressing && c.Reason == "ProgressDeadlineExceeded"{
+			return true
+		}
+	}
+	return false
+}
+
+func parseURLPath(url *url.URL) (namespace string, appName string) {
+	dir, file := path.Split(url.Path)
+	return path.Base(dir), file
+}

--- a/api/deploymentstatus.go
+++ b/api/deploymentstatus.go
@@ -13,7 +13,7 @@ func deploymentStatusHandler(clientset kubernetes.Interface) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		namespace, appName := parseURLPath(r.URL)
 		if dep, err := clientset.ExtensionsV1beta1().Deployments(namespace).Get(appName); err != nil {
-			_, deployFinished, err := status(dep)
+			_, deployFinished, err := isDeploymentFinished(dep)
 
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -30,23 +30,25 @@ func deploymentStatusHandler(clientset kubernetes.Interface) http.Handler {
 	})
 
 }
-func status(deployment *v1beta1.Deployment) (string, bool, error) {
+func isDeploymentFinished(deployment *v1beta1.Deployment) (string, bool, error) {
 	if deployment.Generation <= deployment.Status.ObservedGeneration {
 		if deploymentExceededProgressDeadline(deployment.Status) {
 			return "", false, fmt.Errorf("deployment %q exceeded its progress deadline", deployment.Name)
 		}
 		if deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-			return fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas have been updated...\n", deployment.Status.UpdatedReplicas, deployment.Spec.Replicas), false, nil
+			return fmt.Sprintf("Waiting for rollout to finish: %d out of %d new replicas have been updated.", deployment.Status.UpdatedReplicas, deployment.Spec.Replicas), false, nil
 		}
 		if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-			return fmt.Sprintf("Waiting for rollout to finish: %d old replicas are pending termination...\n", deployment.Status.Replicas-deployment.Status.UpdatedReplicas), false, nil
+			return fmt.Sprintf("Waiting for rollout to finish: %d old replicas are pending termination.", deployment.Status.Replicas-deployment.Status.UpdatedReplicas), false, nil
 		}
 		if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
-			return fmt.Sprintf("Waiting for rollout to finish: %d of %d updated replicas are available...\n", deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas), false, nil
+			return fmt.Sprintf("Waiting for rollout to finish: %d of %d updated replicas are available.", deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas), false, nil
 		}
-		return fmt.Sprintf("deployment %q successfully rolled out\n", deployment.Name), true, nil
+		return fmt.Sprintf("deployment %q successfully rolled out.", deployment.Name), true, nil
 	}
+	return fmt.Sprintf("Waiting for deployment spec update to be observed."), false, nil
 }
+
 func deploymentExceededProgressDeadline(status v1beta1.DeploymentStatus) bool {
 	for i := range status.Conditions {
 		c := status.Conditions[i]

--- a/api/deploymentstatus.go
+++ b/api/deploymentstatus.go
@@ -122,8 +122,7 @@ func deploymentStatusAndView(deployment v1beta1.Deployment) (DeployStatus, Deplo
 		}
 
 	}
-	reason := fmt.Sprintf("Waiting for deployment spec update to be observed.")
-	return InProgress, deploymentStatusViewFrom(InProgress, reason, deployment)
+	return InProgress, deploymentStatusViewFrom(InProgress, "Waiting for deployment spec update to be observed", deployment)
 }
 
 func deploymentExceededProgressDeadline(status v1beta1.DeploymentStatus) bool {

--- a/api/deploymentstatus.go
+++ b/api/deploymentstatus.go
@@ -18,6 +18,8 @@ func (d DeployStatus) String() string {
 		return "Failed"
 	case Success:
 		return "Success"
+	default:
+		return ""
 	}
 }
 
@@ -62,7 +64,7 @@ type DeploymentStatusView struct {
 	Available  int32
 	Containers []string
 	Images     []string
-	Status     DeployStatus
+	Status     string
 	Reason     string
 }
 
@@ -77,7 +79,7 @@ func deploymentStatusViewFrom(status DeployStatus, reason string, deployment v1b
 		Available:  deployment.Status.AvailableReplicas,
 		Containers: containers,
 		Images:     images,
-		Status:     status,
+		Status:     status.String(),
 		Reason:     reason,
 	}
 

--- a/api/deploymentstatus_test.go
+++ b/api/deploymentstatus_test.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"net/url"
+)
+
+func TestAppnNameFromUrl(t *testing.T) {
+
+	u, _ := url.Parse("http://test.url/namespace/appname")
+	namespace, appName := parseURLPath(u)
+
+	assert.Equal(t, "appname", appName)
+	assert.Equal(t, "namespace", namespace)
+}

--- a/api/deploymentstatus_test.go
+++ b/api/deploymentstatus_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/pkg/api/v1"
+	"github.com/stretchr/testify/assert"
 )
 
-
-func TestIsDeploymentFinished(t *testing.T) {
+func TestIsDeploymentStatus(t *testing.T) {
 
 	var wantedReplicas int32 = 2
 	var deploymentGeneration int64 = 2
@@ -23,72 +23,133 @@ func TestIsDeploymentFinished(t *testing.T) {
 		},
 	}
 
+	tests := []struct {
+		testDescription string
+		deployStatus    v1beta1.DeploymentStatus
+		expectedStatus  DeployStatus
+	}{
+		{
+			testDescription: "Deploy is in progress when observed generation is less than spec generation.",
+			deployStatus: v1beta1.DeploymentStatus{
+				ObservedGeneration: deploymentGeneration - 1,
+			},
+			expectedStatus: InProgress,
+		},
+		{
+			testDescription: "Deploy is in progress when updated replicas are less than wanted replicas",
+			deployStatus: v1beta1.DeploymentStatus{
+				ObservedGeneration: deploymentGeneration,
+				UpdatedReplicas:    wantedReplicas - 1,
+				AvailableReplicas:  wantedReplicas,
+			},
+			expectedStatus: InProgress,
+		},
+		{
+			testDescription: "Deploy is in progress when there are more replicas  than wanted replicas",
+			deployStatus: v1beta1.DeploymentStatus{
+				ObservedGeneration: deploymentGeneration,
+				UpdatedReplicas:    wantedReplicas,
+				AvailableReplicas:  wantedReplicas,
+				Replicas:           wantedReplicas + 1,
+			},
+			expectedStatus: InProgress,
+		},
+		{
 
-	t.Run("Test for when a deployment status ", func(t *testing.T) {
-		tests := []struct {
-			testDescription string
-			deployStatus    v1beta1.DeploymentStatus
-			expectedStatus  DeployStatus
-		}{
-			{
-				testDescription: "Deploy is in progress when observed generation is less than spec generation.",
-				deployStatus: v1beta1.DeploymentStatus{
-					ObservedGeneration: deploymentGeneration - 1,
-				},
-				expectedStatus: InProgress,
+			testDescription: "Deploy is in progress when there are less available replicas than wanted replicas",
+			deployStatus: v1beta1.DeploymentStatus{
+				ObservedGeneration: deploymentGeneration,
+				UpdatedReplicas:    wantedReplicas,
+				AvailableReplicas:  wantedReplicas - 1,
+				Replicas:           wantedReplicas,
 			},
-			{
-				testDescription: "Deploy is in progress when updated replicas are less than wanted replicas",
-				deployStatus: v1beta1.DeploymentStatus{
-					ObservedGeneration: deploymentGeneration,
-					UpdatedReplicas:    wantedReplicas - 1,
-					AvailableReplicas:  wantedReplicas,
-				},
-				expectedStatus: InProgress,
-			},
-			{
-				testDescription: "Deploy is in progress when there are more replicas  than wanted replicas",
-				deployStatus: v1beta1.DeploymentStatus{
-					ObservedGeneration: deploymentGeneration,
-					UpdatedReplicas:    wantedReplicas,
-					AvailableReplicas:  wantedReplicas,
-					Replicas:           wantedReplicas + 1,
-				},
-				expectedStatus: InProgress,
-			},
-			{
+			expectedStatus: InProgress,
+		},
+		{
 
-				testDescription: "Deploy is in progress when there are less available replicas than wanted replicas",
-				deployStatus: v1beta1.DeploymentStatus{
-					ObservedGeneration: deploymentGeneration,
-					UpdatedReplicas:    wantedReplicas,
-					AvailableReplicas:  wantedReplicas - 1,
-					Replicas:           wantedReplicas,
-				},
-				expectedStatus: InProgress,
+			testDescription: "Deploy is finished when the number of replicas, available, updated and wanted replicas are equal",
+			deployStatus: v1beta1.DeploymentStatus{
+				ObservedGeneration: deploymentGeneration,
+				UpdatedReplicas:    wantedReplicas,
+				AvailableReplicas:  wantedReplicas,
+				Replicas:           wantedReplicas,
 			},
-			{
+			expectedStatus: Success,
+		},
+	}
 
-				testDescription: "Deploy is finished when the number of replicas, available, updated and wanted replicas are equal",
-				deployStatus: v1beta1.DeploymentStatus{
-					ObservedGeneration: deploymentGeneration,
-					UpdatedReplicas:    wantedReplicas,
-					AvailableReplicas:  wantedReplicas,
-					Replicas:           wantedReplicas,
-				},
-				expectedStatus: Success,
-			},
+	for _, test := range tests {
+		deployment.Status = test.deployStatus
+
+		actualStatus, _ := deploymentStatusAndView(*deployment)
+		if test.expectedStatus != actualStatus {
+			t.Errorf("Failed test: %s\n DeploymentStatus: %+v", test.testDescription, test.deployStatus)
 		}
+	}
+}
 
-		for _, test := range tests {
-			deployment.Status = test.deployStatus
+func TestDeploymentStatusViewFrom(t *testing.T) {
+	deployment := v1beta1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "appname",
+			Namespace: "default",
+		},
+		Spec: v1beta1.DeploymentSpec{
+			Replicas: int32p(4),
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "container",
+							Image: "docker.io/nginx",
+						},
+					},
+				},
+			},
+		},
 
-			actualStatus,_:= deploymentStatusAndView(*deployment)
-			if test.expectedStatus != actualStatus {
-				t.Errorf("Failed test: %s\n DeploymentStatus: %+v", test.testDescription, test.deployStatus)
-			}
-		}
+		Status: v1beta1.DeploymentStatus{
+			Replicas:          3,
+			UpdatedReplicas:   2,
+			AvailableReplicas: 2,
+		},
+	}
+	view := deploymentStatusViewFrom(Success, "reason", deployment)
 
+	assert.Equal(t, view.Status, Success.String())
+	assert.Equal(t, view.Reason, "reason")
+	assert.Equal(t, view.Name, deployment.Name)
+	assert.Equal(t, view.Containers, []string{deployment.Spec.Template.Spec.Containers[0].Name})
+	assert.Equal(t, view.Images, []string{deployment.Spec.Template.Spec.Containers[0].Image})
+	assert.Equal(t, view.Available, deployment.Status.AvailableReplicas)
+	assert.Equal(t, view.UpToDate, deployment.Status.UpdatedReplicas)
+	assert.Equal(t, view.Current, deployment.Status.Replicas)
+	assert.Equal(t, view.Desired, *deployment.Spec.Replicas)
+
+}
+
+func TestDeploymentExceededProgressDeadline(t *testing.T) {
+
+	t.Run("True if a condition is progress dead line exceeded", func(t *testing.T) {
+		assert.True(t, deploymentExceededProgressDeadline(v1beta1.DeploymentStatus{
+			Conditions: []v1beta1.DeploymentCondition{
+				{
+					Type:   v1beta1.DeploymentProgressing,
+					Reason: "ProgressDeadlineExceeded",
+				},
+			},
+		}))
+	})
+
+	t.Run("False if no condition is progress dead line exceeded", func(t *testing.T) {
+		assert.False(t, deploymentExceededProgressDeadline(v1beta1.DeploymentStatus{
+			Conditions: []v1beta1.DeploymentCondition{
+				{
+					Type:   v1beta1.DeploymentProgressing,
+					Reason: "Other reason",
+				},
+			},
+		}))
 	})
 
 }

--- a/api/deploymentstatus_test.go
+++ b/api/deploymentstatus_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"github.com/stretchr/testify/assert"
 	"net/url"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 func TestAppnNameFromUrl(t *testing.T) {
@@ -13,4 +15,107 @@ func TestAppnNameFromUrl(t *testing.T) {
 
 	assert.Equal(t, "appname", appName)
 	assert.Equal(t, "namespace", namespace)
+}
+
+func TestIsDeploymentFinished(t *testing.T) {
+
+	var wantedReplicas int32 = 2
+	var deploymentGeneration int64 = 2
+
+	deployment := &v1beta1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:       "appname",
+			Namespace:  "default",
+			Generation: deploymentGeneration,
+		},
+		Spec: v1beta1.DeploymentSpec{
+			Replicas: int32p(wantedReplicas),
+		},
+	}
+
+	t.Run("Error when progress dead line is exceeded", func(t *testing.T) {
+
+		deployment.Status = v1beta1.DeploymentStatus{
+			ObservedGeneration: deploymentGeneration,
+			Conditions: []v1beta1.DeploymentCondition{
+				{
+					Type:   v1beta1.DeploymentProgressing,
+					Reason: "ProgressDeadlineExceeded",
+				},
+			},
+		}
+
+		_, isFinished, err := isDeploymentFinished(deployment)
+
+		assert.Error(t, err)
+		assert.Equal(t, false, isFinished)
+	})
+
+	t.Run("Test for when a deployment is finished", func(t *testing.T) {
+		tests := []struct {
+			testDescription string
+			deployStatus    v1beta1.DeploymentStatus
+			expectedStatus  bool
+		}{
+			{
+				testDescription: "Deploy is not finished when observed generation is less than spec generation.",
+				deployStatus: v1beta1.DeploymentStatus{
+					ObservedGeneration: deploymentGeneration - 1,
+				},
+				expectedStatus: false,
+			},
+			{
+				testDescription: "Deploy is not finished when updated replicas are less than wanted replicas",
+				deployStatus: v1beta1.DeploymentStatus{
+					ObservedGeneration: deploymentGeneration,
+					UpdatedReplicas:    wantedReplicas - 1,
+					AvailableReplicas:  wantedReplicas,
+				},
+				expectedStatus: false,
+			},
+			{
+				testDescription: "Deploy is not finished when there are more replicas  than wanted replicas",
+				deployStatus: v1beta1.DeploymentStatus{
+					ObservedGeneration: deploymentGeneration,
+					UpdatedReplicas:    wantedReplicas,
+					AvailableReplicas:  wantedReplicas,
+					Replicas:           wantedReplicas + 1,
+				},
+				expectedStatus: false,
+			},
+			{
+
+				testDescription: "Deploy is not finished when there are less available replicas than wanted replicas",
+				deployStatus: v1beta1.DeploymentStatus{
+					ObservedGeneration: deploymentGeneration,
+					UpdatedReplicas:    wantedReplicas,
+					AvailableReplicas:  wantedReplicas - 1,
+					Replicas:           wantedReplicas,
+				},
+				expectedStatus: false,
+			},
+			{
+
+				testDescription: "Deploy is finished when the number of replicas, available, updated and wanted replicas are equal",
+				deployStatus: v1beta1.DeploymentStatus{
+					ObservedGeneration: deploymentGeneration,
+					UpdatedReplicas:    wantedReplicas,
+					AvailableReplicas:  wantedReplicas,
+					Replicas:           wantedReplicas,
+				},
+				expectedStatus: true,
+			},
+		}
+
+		for _, test := range tests {
+			deployment.Status = test.deployStatus
+
+			_, actualStatus, _ := isDeploymentFinished(deployment)
+			if test.expectedStatus != actualStatus {
+				t.Errorf("Failed test: %s\n DeploymentStatus: %+v", test.testDescription, test.deployStatus)
+			}
+		}
+
+	})
+
 }

--- a/api/deploymentstatus_test.go
+++ b/api/deploymentstatus_test.go
@@ -2,20 +2,10 @@ package api
 
 import (
 	"testing"
-	"github.com/stretchr/testify/assert"
-	"net/url"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
-func TestAppnNameFromUrl(t *testing.T) {
-
-	u, _ := url.Parse("http://test.url/namespace/appname")
-	namespace, appName := parseURLPath(u)
-
-	assert.Equal(t, "appname", appName)
-	assert.Equal(t, "namespace", namespace)
-}
 
 func TestIsDeploymentFinished(t *testing.T) {
 
@@ -33,66 +23,49 @@ func TestIsDeploymentFinished(t *testing.T) {
 		},
 	}
 
-	t.Run("Error when progress dead line is exceeded", func(t *testing.T) {
 
-		deployment.Status = v1beta1.DeploymentStatus{
-			ObservedGeneration: deploymentGeneration,
-			Conditions: []v1beta1.DeploymentCondition{
-				{
-					Type:   v1beta1.DeploymentProgressing,
-					Reason: "ProgressDeadlineExceeded",
-				},
-			},
-		}
-
-		_, isFinished, err := isDeploymentFinished(deployment)
-
-		assert.Error(t, err)
-		assert.Equal(t, false, isFinished)
-	})
-
-	t.Run("Test for when a deployment is finished", func(t *testing.T) {
+	t.Run("Test for when a deployment status ", func(t *testing.T) {
 		tests := []struct {
 			testDescription string
 			deployStatus    v1beta1.DeploymentStatus
-			expectedStatus  bool
+			expectedStatus  DeployStatus
 		}{
 			{
-				testDescription: "Deploy is not finished when observed generation is less than spec generation.",
+				testDescription: "Deploy is in progress when observed generation is less than spec generation.",
 				deployStatus: v1beta1.DeploymentStatus{
 					ObservedGeneration: deploymentGeneration - 1,
 				},
-				expectedStatus: false,
+				expectedStatus: InProgress,
 			},
 			{
-				testDescription: "Deploy is not finished when updated replicas are less than wanted replicas",
+				testDescription: "Deploy is in progress when updated replicas are less than wanted replicas",
 				deployStatus: v1beta1.DeploymentStatus{
 					ObservedGeneration: deploymentGeneration,
 					UpdatedReplicas:    wantedReplicas - 1,
 					AvailableReplicas:  wantedReplicas,
 				},
-				expectedStatus: false,
+				expectedStatus: InProgress,
 			},
 			{
-				testDescription: "Deploy is not finished when there are more replicas  than wanted replicas",
+				testDescription: "Deploy is in progress when there are more replicas  than wanted replicas",
 				deployStatus: v1beta1.DeploymentStatus{
 					ObservedGeneration: deploymentGeneration,
 					UpdatedReplicas:    wantedReplicas,
 					AvailableReplicas:  wantedReplicas,
 					Replicas:           wantedReplicas + 1,
 				},
-				expectedStatus: false,
+				expectedStatus: InProgress,
 			},
 			{
 
-				testDescription: "Deploy is not finished when there are less available replicas than wanted replicas",
+				testDescription: "Deploy is in progress when there are less available replicas than wanted replicas",
 				deployStatus: v1beta1.DeploymentStatus{
 					ObservedGeneration: deploymentGeneration,
 					UpdatedReplicas:    wantedReplicas,
 					AvailableReplicas:  wantedReplicas - 1,
 					Replicas:           wantedReplicas,
 				},
-				expectedStatus: false,
+				expectedStatus: InProgress,
 			},
 			{
 
@@ -103,14 +76,14 @@ func TestIsDeploymentFinished(t *testing.T) {
 					AvailableReplicas:  wantedReplicas,
 					Replicas:           wantedReplicas,
 				},
-				expectedStatus: true,
+				expectedStatus: Success,
 			},
 		}
 
 		for _, test := range tests {
 			deployment.Status = test.deployStatus
 
-			_, actualStatus, _ := isDeploymentFinished(deployment)
+			actualStatus,_:= deploymentStatusAndView(*deployment)
 			if test.expectedStatus != actualStatus {
 				t.Errorf("Failed test: %s\n DeploymentStatus: %+v", test.testDescription, test.deployStatus)
 			}

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -110,7 +110,7 @@ func createDeploymentDef(naisResources []NaisResource, appConfig NaisAppConfig, 
 						},
 					},
 				},
-				ProgressDeadlineSeconds: int32p(600),
+				ProgressDeadlineSeconds: int32p(300),
 				RevisionHistoryLimit:    int32p(10),
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: createOjectMeta(deploymentRequest, appConfig),

--- a/naisd.go
+++ b/naisd.go
@@ -14,8 +14,6 @@ import (
 const Port string = ":8081"
 
 func main() {
-	println("WAGASGAGG")
-	glog.Infof("WTR")
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig file")
 	fasitUrl := flag.String("fasit-url", "https://fasit.example.no", "URL to fasit instance")
 	clusterSubdomain := flag.String("cluster-subdomain", "nais-example.nais.example.no", "Cluster sub-domain")
@@ -25,7 +23,6 @@ func main() {
 	glog.Infof("using fasit instance %s", *fasitUrl)
 
 	glog.Infof("running on port %s", Port)
-	glog.Infof("WTR")
 	clientSet := newClientSet(*kubeconfig)
 	err := http.ListenAndServe(Port, api.NewApi(clientSet, *fasitUrl, *clusterSubdomain, api.NewDeploymentStatusViewer(clientSet)).Handler())
 	if err != nil {

--- a/naisd.go
+++ b/naisd.go
@@ -14,7 +14,8 @@ import (
 const Port string = ":8081"
 
 func main() {
-
+	println("WAGASGAGG")
+	glog.Infof("WTR")
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig file")
 	fasitUrl := flag.String("fasit-url", "https://fasit.example.no", "URL to fasit instance")
 	clusterSubdomain := flag.String("cluster-subdomain", "nais-example.nais.example.no", "Cluster sub-domain")
@@ -24,7 +25,9 @@ func main() {
 	glog.Infof("using fasit instance %s", *fasitUrl)
 
 	glog.Infof("running on port %s", Port)
-	err := http.ListenAndServe(Port, api.Api{newClientSet(*kubeconfig), *fasitUrl, *clusterSubdomain}.NewApi())
+	glog.Infof("WTR")
+	clientSet := newClientSet(*kubeconfig)
+	err := http.ListenAndServe(Port, api.NewApi(clientSet, *fasitUrl, *clusterSubdomain, api.NewDeploymentStatusViewer(clientSet)).Handler())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Endpoint is at /deploystatus/${namespace}/${appname}

Will return 200 if deployment is OK. 
Will return 202 if a deployment is in progress
Will return 500 if a deployment failed.
Will return 404 if the given deployment can not be found

Sample body:
{
Name: "naisd",
Desired: 2,
Current: 2,
UpToDate: 2,
Available: 2,
Containers: [
"naisd"
],
Images: [
"navikt/naisd:117.0.0"
],
Status: "Success",
Reason: "deployment "naisd" successfully rolled out."
}

Note on the 500:  This requires that progressDeadlinSeconds is set on the deployment(See
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds).

For "new" deployments through Naisd this limit is set to 600 seconds(Default in 1.8 or HEAD).
For existing deployments this value may not exists. In which case they need to be patched or else the deployment will never be marked as failed. 