### PR TITLE
Expose periodSeconds and failureThreshold as configuration in nais.yaml

### DIFF
--- a/api/appconfig.go
+++ b/api/appconfig.go
@@ -12,8 +12,10 @@ import (
 )
 
 type Probe struct {
-	Path         string
-	InitialDelay int `yaml:"initialDelay"`
+	Path             string
+	InitialDelay     int `yaml:"initialDelay"`
+	PeriodSeconds    int `yaml:"periodSeconds"`
+	FailureThreshold int `yaml:"failureThreshold"`
 }
 
 type Healthcheck struct {

--- a/api/appconfig_test.go
+++ b/api/appconfig_test.go
@@ -37,6 +37,10 @@ func TestAppConfigUnmarshal(t *testing.T) {
 	assert.Equal(t, "/path", appConfig.Prometheus.Path)
 	assert.Equal(t, 79, appConfig.Healthcheck.Liveness.InitialDelay)
 	assert.Equal(t, 79, appConfig.Healthcheck.Readiness.InitialDelay)
+	assert.Equal(t, 15, appConfig.Healthcheck.Liveness.FailureThreshold)
+	assert.Equal(t, 3, appConfig.Healthcheck.Readiness.FailureThreshold)
+	assert.Equal(t, 5, appConfig.Healthcheck.Liveness.PeriodSeconds)
+	assert.Equal(t, 10, appConfig.Healthcheck.Readiness.PeriodSeconds)
 }
 
 func TestAppConfigUsesDefaultValues(t *testing.T) {

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -20,12 +20,16 @@ func GetDefaultAppConfig(application string) NaisAppConfig {
 		},
 		Healthcheck: Healthcheck{
 			Liveness: Probe{
-				Path:         "isAlive",
-				InitialDelay: 20,
+				Path:             "isAlive",
+				InitialDelay:     20,
+				PeriodSeconds:    10,
+				FailureThreshold: 3,
 			},
 			Readiness: Probe{
-				Path:         "isReady",
-				InitialDelay: 20,
+				Path:             "isReady",
+				InitialDelay:     20,
+				PeriodSeconds:    10,
+				FailureThreshold: 3,
 			},
 		},
 		Ingress: Ingress{Enabled: true},

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -154,6 +154,8 @@ func createPodSpec(deploymentRequest NaisDeploymentRequest, appConfig NaisAppCon
 						},
 					},
 					InitialDelaySeconds: int32(appConfig.Healthcheck.Liveness.InitialDelay),
+					PeriodSeconds:       int32(appConfig.Healthcheck.Liveness.PeriodSeconds),
+					FailureThreshold:    int32(appConfig.Healthcheck.Liveness.FailureThreshold),
 				},
 				ReadinessProbe: &v1.Probe{
 					Handler: v1.Handler{
@@ -163,6 +165,8 @@ func createPodSpec(deploymentRequest NaisDeploymentRequest, appConfig NaisAppCon
 						},
 					},
 					InitialDelaySeconds: int32(appConfig.Healthcheck.Readiness.InitialDelay),
+					PeriodSeconds:       int32(appConfig.Healthcheck.Readiness.PeriodSeconds),
+					FailureThreshold:    int32(appConfig.Healthcheck.Readiness.FailureThreshold),
 				},
 				Env:             createEnvironmentVariables(deploymentRequest, naisResources),
 				ImagePullPolicy: v1.PullIfNotPresent,

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -33,12 +33,16 @@ func newDefaultAppConfig() NaisAppConfig {
 		Port:  port,
 		Healthcheck: Healthcheck{
 			Readiness: Probe{
-				Path:         readinessPath,
-				InitialDelay: 20,
+				Path:             readinessPath,
+				InitialDelay:     20,
+				PeriodSeconds:    10,
+				FailureThreshold: 3,
 			},
 			Liveness: Probe{
-				Path:         livenessPath,
-				InitialDelay: 20,
+				Path:             livenessPath,
+				InitialDelay:     20,
+				PeriodSeconds:    10,
+				FailureThreshold: 3,
 			},
 		},
 		Resources: ResourceRequirements{

--- a/api/testdata/nais.yaml
+++ b/api/testdata/nais.yaml
@@ -9,6 +9,8 @@ healthcheck:
   liveness:
     path: isAlive2
     initialDelay: 79
+    periodSeconds: 5
+    failureThreshold: 15
   readiness:
     path: isReady2
     initialDelay: 79

--- a/nais_example.yaml
+++ b/nais_example.yaml
@@ -8,6 +8,10 @@ healthcheck: #Optional
   liveness:
     path: isalive
     initialDelay: 20
+    periodSeconds: 5     # How often (in seconds) to perform the probe. Default to 10 seconds
+    failureThreshold: 10 # when a Pod starts and the probe fails,
+                         # nais will try failureThreshold times before giving up and restarting the Pod
+                         # Defaults to 3
   readiness:
     path: isready
     initialDelay: 20


### PR DESCRIPTION
This will enable faster deploys, as we can use a smaller value for `initialDelay` and a higher value for `failureThreshold` instead.

The default values er fetched from Kubernetes:
https://kubernetes.io/docs/api-reference/v1.8/#probe-v1-core