### PR TITLE
Add command for generating environment variables from fasit resources

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,16 +4,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/golang/glog"
 	ver "github.com/nais/naisd/api/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"goji.io"
 	"goji.io/pat"
-	"io"
-	"io/ioutil"
 	"k8s.io/client-go/kubernetes"
-	"net/http"
 )
 
 type Api struct {
@@ -195,7 +196,7 @@ func (api Api) deploy(w http.ResponseWriter, r *http.Request) *appError {
 
 	glog.Infof("Starting deployment. Deploying %s:%s to %s\n", deploymentRequest.Application, deploymentRequest.Version, deploymentRequest.Environment)
 
-	naisResources, err := fetchFasitResources(fasit, deploymentRequest, manifest)
+	naisResources, err := FetchFasitResources(fasit, deploymentRequest.Application, deploymentRequest.Environment, deploymentRequest.Zone, manifest.FasitResources.Used)
 	if err != nil {
 		return &appError{err, "unable to fetch fasit resources", http.StatusBadRequest}
 	}

--- a/api/fasit.go
+++ b/api/fasit.go
@@ -258,17 +258,14 @@ func getResourceIds(usedResources []NaisResource) (usedResourceIds []int) {
 }
 
 func FetchFasitResources(fasit FasitClientAdapter, application string, environment string, zone string, usedResources []UsedResource) (naisresources []NaisResource, err error) {
-	defaultResources := DefaultResourceRequests()
+	resourceRequests := DefaultResourceRequests()
 
-	defaultResourcesCount := len(defaultResources)
-	resourceRequests := append(DefaultResourceRequests(), make([]ResourceRequest, len(usedResources))...)
-
-	for index, resource := range usedResources {
-		resourceRequests[index+defaultResourcesCount] = ResourceRequest{
+	for _, resource := range usedResources {
+		resourceRequests = append(resourceRequests, ResourceRequest{
 			Alias:        resource.Alias,
 			ResourceType: resource.ResourceType,
 			PropertyMap:  resource.PropertyMap,
-		}
+		})
 	}
 
 	naisresources, err = fasit.GetScopedResources(resourceRequests, environment, application, zone)

--- a/api/fasit_test.go
+++ b/api/fasit_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/h2non/gock.v1"
 	"io/ioutil"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
 )
 
 func TestResourceEnvironmentVariableName(t *testing.T) {
@@ -411,7 +412,7 @@ func TestResourceError(t *testing.T) {
 
 	resourceAlias := "resourcealias"
 	resourceType := "baseurl"
-	resource, err := fetchFasitResources(fasitClient, NaisDeploymentRequest{Application: "app", Environment: "env", Version: "123"}, NaisManifest{FasitResources: FasitResources{Used: []UsedResource{{Alias: resourceAlias, ResourceType: resourceType}}}})
+	resource, err := FetchFasitResources(fasitClient, "app", "env", "123", []UsedResource{{Alias: resourceAlias, ResourceType: resourceType}})
 	assert.Error(t, err)
 	assert.Empty(t, resource)
 	assert.True(t, strings.Contains(err.Error(), fmt.Sprintf("Unable to get resource %s (%s)", resourceAlias, resourceType)))

--- a/api/testdata/fasit_response_datasource.json
+++ b/api/testdata/fasit_response_datasource.json
@@ -1,0 +1,27 @@
+{
+    "type": "datasource",
+    "alias": "app_db",
+    "scope": {
+      "environmentclass": "t",
+      "application": "test-application"
+    },
+    "properties": {
+      "url": "jdbc:oracle:thin:@//testdatabase.local:1521/app_db",
+      "username": "generic_database_username"
+    },
+    "files": {},
+    "dodgy": false,
+    "id": 909090,
+    "revision": 9876543,
+    "created": "2017-04-14T00:00:00.000",
+    "updated": "2017-04-14T00:00:00.000",
+    "lifecycle": {},
+    "accesscontrol": {
+      "environmentclass": "t",
+      "adgroups": []
+    },
+    "links": {
+      "self": "https://fasit.adeo.no/api/v2/resources/919191",
+      "revisions": "https://fasit.adeo.no/api/v2/resources/919191/revisions"
+    }
+  }

--- a/api/testdata/fasit_response_restservice.json
+++ b/api/testdata/fasit_response_restservice.json
@@ -1,0 +1,27 @@
+{
+    "type": "restservice",
+    "alias": "test-application",
+    "scope": {
+      "environmentclass": "t",
+      "application": "appName"
+    },
+    "properties": {
+      "url": "https://external-application.nais.preprod.local/rest/v1/very_useful_call"
+    },
+  
+    "files": {},
+    "dodgy": false,
+    "id": 929292,
+    "revision": 8765432,
+    "created": "2017-04-14T01:00:00.000",
+    "updated": "2017-04-14T01:00:00.000",
+    "lifecycle": {},
+    "accesscontrol": {
+      "environmentclass": "p",
+      "adgroups": []
+    },
+    "links": {
+      "self": "https://fasit.adeo.no/api/v2/resources/929292",
+      "revisions": "https://fasit.adeo.no/api/v2/resources/929292/revisions"
+    }
+  }

--- a/api/testdata/nais_used_resources.yaml
+++ b/api/testdata/nais_used_resources.yaml
@@ -1,0 +1,15 @@
+replicas:
+  min: 1
+  max: 4
+  cpuThresholdPercentage: 50
+port: 8080
+ingress:
+  enabled: false
+fasitResources:
+  used:
+    - alias: app_db
+      resourceType: datasource
+    - alias: some_api
+      resourceType: restservice
+      propertyMap:
+        url: SOME_API_REST_URL

--- a/cli/cmd/Environment.go
+++ b/cli/cmd/Environment.go
@@ -12,9 +12,15 @@ import (
 )
 
 var environmentCommand = &cobra.Command{
-	Short: "Update environment variables",
-	Long:  `Command to update environment variables with values fetched from the defined fasit resource`,
-	Use:   `env [flags] <application_name>`,
+	Short: "Fetch environment variables from fasit",
+	Long:  `Command fetch the same environment variables from fasit that naisd would give a pod`,
+	Use: `env [flags] <application_name>
+The commad is mainly made to fetch environment variables in a format you can use with eval:
+  docker run eval $(nais env -o docker application_name)
+You can also use it to add the environment variables to a shell script:
+  eval $(nais env application_name)
+Or just save it to a file
+  nais env application_name > .env`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			cmd.Help()
@@ -126,7 +132,7 @@ var environmentCommand = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(environmentCommand)
-	environmentCommand.Flags().StringP("output", "o", "export", `How to format the output, valid options`)
+	environmentCommand.Flags().StringP("output", "o", "export", `How to format the output, valid options are export, java, docker, multiline and inline`)
 	environmentCommand.Flags().StringP("file", "f", "nais.yaml", `Define the file to parse`)
 	environmentCommand.Flags().StringP("zone", "z", "fss", `Which zone the application is deployed in`)
 	environmentCommand.Flags().StringP("environment", "e", "t0", `Which fasit environment to fetch variables from`)

--- a/cli/cmd/Environment.go
+++ b/cli/cmd/Environment.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/nais/naisd/api"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+var environmentCommand = &cobra.Command{
+	Short: "Update environment variables",
+	Long:  `Command to update environment variables with values fetched from the defined fasit resource`,
+	Use:   `env [flags] <application_name>`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			cmd.Help()
+			os.Exit(1)
+		}
+
+		application := args[0]
+		username := os.Getenv("FASIT_USERNAME")
+		password := os.Getenv("FASIT_PASSWORD")
+
+		inline := true
+
+		stringFormat := "%v='%s'"
+
+		naisFileName, err := cmd.Flags().GetString("file")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error when getting flag: file. %v\n", err)
+			os.Exit(1)
+		}
+
+		outputFormat, err := cmd.Flags().GetString("output")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error while getting flag: output. %v\n", err)
+			os.Exit(1)
+		}
+
+		zone, err := cmd.Flags().GetString("zone")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error while getting flag: zone. %v\n", err)
+			os.Exit(1)
+		}
+
+		environment, err := cmd.Flags().GetString("environment")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error while getting flag: environment. %v\n", err)
+		}
+
+		fasitUrl, err := cmd.Flags().GetString("fasit-url")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error while getting flag: fasit-url. %v\n", err)
+		}
+
+		switch outputFormat {
+		case "export":
+			stringFormat = "export " + stringFormat
+			inline = false
+		case "java":
+			stringFormat = "-D" + stringFormat
+		case "docker":
+			stringFormat = "-e " + stringFormat
+		case "multiline":
+			inline = false
+		case "inline":
+			// Defaults works fine
+		default:
+			fmt.Fprintf(os.Stderr, "Invalid output format %s\n", outputFormat)
+			os.Exit(1)
+		}
+
+		file, err := ioutil.ReadFile(naisFileName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to read the file %v: %v\n", naisFileName, err)
+			os.Exit(1)
+		}
+
+		var manifest api.NaisManifest
+
+		if err := yaml.Unmarshal(file, &manifest); err != nil {
+			fmt.Fprintf(os.Stderr, "Error while unmarshalling yaml. %v", err)
+			os.Exit(1)
+		}
+
+		fasit := api.FasitClient{
+			Username: username,
+			Password: password,
+			FasitUrl: fasitUrl,
+		}
+
+		vars, err := api.FetchFasitResources(fasit, application, environment, zone, manifest.FasitResources.Used)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to contact Fasit. %v\n", err)
+		}
+
+		formattedVars := make([]string, 0)
+
+		for _, resource := range vars {
+			for key, val := range resource.GetProperties() {
+				environmentVariable := resource.ToEnvironmentVariable(key)
+				formattedVars = append(formattedVars, fmt.Sprintf(stringFormat, environmentVariable, val))
+			}
+		}
+
+		joinChar := "\n"
+		if inline {
+			joinChar = " "
+		}
+
+		resultString := strings.Join(formattedVars, joinChar)
+		fmt.Printf(resultString)
+
+		if !inline {
+			fmt.Println()
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(environmentCommand)
+	environmentCommand.Flags().StringP("output", "o", "export", `How to format the output, valid options`)
+	environmentCommand.Flags().StringP("file", "f", "nais.yaml", `Define the file to parse`)
+	environmentCommand.Flags().StringP("zone", "z", "fss", `Which zone the application is deployed in`)
+	environmentCommand.Flags().StringP("environment", "e", "t0", `Which fasit environment to fetch variables from`)
+	environmentCommand.Flags().StringP("fasit-url", "u", "https://fasit.adeo.no", `Set fasit url`)
+}

--- a/cli/cmd/Environment.go
+++ b/cli/cmd/Environment.go
@@ -50,11 +50,13 @@ var environmentCommand = &cobra.Command{
 		environment, err := cmd.Flags().GetString("environment")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error while getting flag: environment. %v\n", err)
+			os.Exit(1)
 		}
 
 		fasitUrl, err := cmd.Flags().GetString("fasit-url")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error while getting flag: fasit-url. %v\n", err)
+			os.Exit(1)
 		}
 
 		switch outputFormat {
@@ -96,6 +98,7 @@ var environmentCommand = &cobra.Command{
 		vars, err := api.FetchFasitResources(fasit, application, environment, zone, manifest.FasitResources.Used)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to contact Fasit. %v\n", err)
+			os.Exit(1)
 		}
 
 		formattedVars := make([]string, 0)

--- a/cli/cmd/Environment_test.go
+++ b/cli/cmd/Environment_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"gopkg.in/h2non/gock.v1"
+)
+
+var expected_vars = map[string]string{
+	"NAV_TRUSTSTORE_KEYSTOREALIAS": "app-key",
+	"APP_DB_URL":                   "jdbc:oracle:thin:@//testdatabase.local:1521/app_db",
+	"APP_DB_USERNAME":              "generic_database_username",
+	"SOME_API_REST_URL":            "https://external-application.nais.preprod.local/rest/v1/very_useful_call",
+}
+
+func runCommand(t *testing.T, args []string) ([]byte, int) {
+	defer gock.Off()
+
+	gock.New("https://fasit.local").
+		Get("/api/v2/scopedresource").
+		MatchParam("alias", "app_db").
+		MatchParam("application", "test-application").
+		Reply(200).File("../../api/testdata/fasit_response_datasource.json")
+
+	gock.New("https://fasit.local").
+		Get("/api/v2/scopedresource").
+		MatchParam("alias", "nav_truststore").
+		MatchParam("application", "test-application").
+		Reply(200).File("../../api/testdata/fasitTruststoreResponse.json")
+
+	gock.New("https://fasit.local").
+		Get("/api/v2/scopedresource").
+		MatchParam("alias", "some_api").
+		MatchParam("application", "test-application").
+		Reply(200).File("../../api/testdata/fasit_response_restservice.json")
+
+	gock.New("https://fasit.local").
+		Get("/api/v2/resources/3024713/file/keystore").
+		Reply(200).Body(bytes.NewReader([]byte("very secure certificate file :)")))
+
+	// Since we're testing the output to console we need to save the default os.Stdout
+	stdout := os.Stdout
+
+	// To read from os.Stdout we replace it with a pipe
+	r, w, err := os.Pipe()
+	assert.Nil(t, err)
+	os.Stdout = w
+
+	reader := bufio.NewReader(r)
+
+	// Execute the command
+	RootCmd.SetArgs(args)
+	err = environmentCommand.Execute()
+
+	assert.Nil(t, err)
+
+	// Extract the console output from our pipe
+	commandResult := make([]byte, 512)
+	commandResultLength, err := reader.Read(commandResult)
+
+	assert.Nil(t, err)
+
+	// When the command is done executing we revert to the original os.Stdout
+	os.Stdout = stdout
+
+	return commandResult, commandResultLength
+}
+
+func TestExportFormat(t *testing.T) {
+	commandResult, commandResultLength := runCommand(t, []string{"env", "-u", "https://fasit.local", "-f", "../../api/testdata/nais_used_resources.yaml", "test-application"})
+
+	assert.NotEqual(t, 0, commandResultLength)
+
+	// Make sure the export format has a trailing newline
+	assert.Equal(t, commandResult[commandResultLength-1], byte('\n'))
+
+	// Remove the trailing newline and then split it by newlines
+	resultStrings := strings.Split(string(commandResult[:commandResultLength-1]), "\n")
+
+	assert.Equal(t, len(expected_vars), len(resultStrings))
+
+	exportRegex, _ := regexp.Compile("export ([A-Z_]+)='(.+)'")
+	for _, value := range resultStrings {
+		matches := exportRegex.FindStringSubmatch(value)
+
+		assert.NotNil(t, matches)
+
+		assert.Contains(t, expected_vars, matches[1])
+		assert.Equal(t, expected_vars[matches[1]], matches[2])
+	}
+}
+func TestMultilineFormat(t *testing.T) {
+	commandResult, commandResultLength := runCommand(t, []string{"env", "-u", "https://fasit.local", "-o", "multiline", "-f", "../../api/testdata/nais_used_resources.yaml", "test-application"})
+
+	assert.NotEqual(t, 0, commandResultLength)
+
+	// Make sure the export format has a trailing newline
+	assert.Equal(t, commandResult[commandResultLength-1], byte('\n'))
+
+	// Remove the trailing newline and then split it by newlines
+	resultStrings := strings.Split(string(commandResult[:commandResultLength-1]), "\n")
+
+	assert.Equal(t, len(expected_vars), len(resultStrings))
+
+	exportRegex, _ := regexp.Compile("([A-Z_]+)='(.+)'")
+	for _, value := range resultStrings {
+		matches := exportRegex.FindStringSubmatch(value)
+
+		assert.NotNil(t, matches)
+
+		assert.Contains(t, expected_vars, matches[1])
+		assert.Equal(t, expected_vars[matches[1]], matches[2])
+	}
+}
+
+func TestDockerFormat(t *testing.T) {
+	commandResult, commandResultLength := runCommand(t, []string{"env", "-u", "https://fasit.local", "-o", "docker", "-f", "../../api/testdata/nais_used_resources.yaml", "test-application"})
+
+	assert.NotEqual(t, 0, commandResultLength)
+
+	// Remove the first -e, so we can split by the environment flag
+	resultStrings := strings.Split(string(commandResult[2:]), " -e")
+
+	assert.Equal(t, len(expected_vars), len(resultStrings))
+
+	exportRegex, _ := regexp.Compile("([A-Z_]+)='(.+)'") // The strings we got after splitting should have NAME='value' format
+	for _, value := range resultStrings {
+		matches := exportRegex.FindStringSubmatch(value)
+
+		assert.NotNil(t, matches)
+
+		assert.Contains(t, expected_vars, matches[1])
+		assert.Equal(t, expected_vars[matches[1]], matches[2])
+	}
+}
+
+func TestJavaFormat(t *testing.T) {
+	commandResult, commandResultLength := runCommand(t, []string{"env", "-u", "https://fasit.local", "-o", "java", "-f", "../../api/testdata/nais_used_resources.yaml", "test-application"})
+
+	assert.NotEqual(t, 0, commandResultLength)
+
+	/* For java we're using -DNAME=variable, and in the current test data we don't expect any
+	variables to have any spaces, so we can just split on space. If we later want to test
+	with newlines we need to redo how we test induvidual variables. */
+	resultStrings := strings.Split(string(commandResult[:]), " ")
+
+	assert.Equal(t, len(expected_vars), len(resultStrings))
+
+	exportRegex, _ := regexp.Compile("-D([A-Z_]+)='(.+)'")
+	for _, value := range resultStrings {
+		matches := exportRegex.FindStringSubmatch(value)
+
+		assert.NotNil(t, matches)
+
+		assert.Contains(t, expected_vars, matches[1])
+		assert.Equal(t, expected_vars[matches[1]], matches[2])
+	}
+}

--- a/cli/cmd/Environment_test.go
+++ b/cli/cmd/Environment_test.go
@@ -163,3 +163,24 @@ func TestJavaFormat(t *testing.T) {
 		assert.Equal(t, expected_vars[matches[1]], matches[2])
 	}
 }
+
+func TestInlineFormat(t *testing.T) {
+	commandResult, commandResultLength := runCommand(t, []string{"env", "-u", "https://fasit.local", "-o", "inline", "-f", "../../api/testdata/nais_used_resources.yaml", "test-application"})
+
+	assert.NotEqual(t, 0, commandResultLength)
+
+	// This should be fine as long as we don't have spaces in the variables
+	resultStrings := strings.Split(string(commandResult[:]), " ")
+
+	assert.Equal(t, len(expected_vars), len(resultStrings))
+
+	exportRegex, _ := regexp.Compile("([A-Z_]+)='(.+)'")
+	for _, value := range resultStrings {
+		matches := exportRegex.FindStringSubmatch(value)
+
+		assert.NotNil(t, matches)
+
+		assert.Contains(t, expected_vars, matches[1])
+		assert.Equal(t, expected_vars[matches[1]], matches[2])
+	}
+}


### PR DESCRIPTION
This command makes it simpler to validate that the application will pick up the right environment variables without deploying to nais. It can also help validate that the resources defined in nais.yaml has the correct alias. 

Example usage: eval $(nais-cli -o inline application_name) java -jar target/app.jar

Currently fasit username and password is set with the environment variables FASIT_USERNAME and FASIT_PASSWORD