### PR TITLE
Use PUT for upload so it'll work for nexus2 and nexus3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,28 @@ nais upload [flags]
 Flags:
   -a, --app string        name of your app
   -f, --file string       path to nais.yaml (default "nais.yaml")
-  -g, --group string      nexus group (default "nais")
   -p, --password string   the password
-  -r, --repo string       nexus repo (default "m2internal")
   -u, --username string   the username
   -v, --version string    version you want to upload
 ```
 
-Will upload `nais.yaml` to Nexus. If using default values, only `app`, `version`, `username` and `password` argument is required.
+Will upload `nais.yaml` to Nexus.
 
-The username and password may be specified using environment variable `NEXUS_USERNAME` and `NEXUS_PASSWORD` instead.
+The username and password may be specified using environment variable `NEXUS_USERNAME` and `NEXUS_PASSWORD`, and
+the Nexus repo can be specified using `NEXUS_URL`.
+
+**Example:** Uploading to Nexus 2:
+
+```
+./nais upload --app myapp -v 10
+```
+
+**Example:** Uploading to Nexus 3:
+
+```
+NEXUS_URL=https://repo.adeo.no/repository/raw ./nais upload --app myapp -v 10
+
+```
 
 #### Deploy
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,13 @@ the Nexus repo can be specified using `NEXUS_URL`.
 **Example:** Uploading to Nexus 2:
 
 ```
-./nais upload --app myapp -v 10
+NEXUS_URL=http://maven.adeo.no/nexus/content/repositories/m2internal ./nais upload --app myapp -v 10
 ```
 
 **Example:** Uploading to Nexus 3:
 
 ```
-NEXUS_URL=https://repo.adeo.no/repository/raw ./nais upload --app myapp -v 10
-
+./nais upload --app myapp -v 10
 ```
 
 #### Deploy

--- a/cli/cmd/upload.go
+++ b/cli/cmd/upload.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const DEFAULT_NEXUS_URL = "http://maven.adeo.no/nexus/content/repositories/m2internal"
+const DEFAULT_NEXUS_URL = "https://repo.adeo.no/repository/raw"
 
 type NexusUploadRequest struct {
 	Username string
@@ -54,11 +54,10 @@ var uploadCmd = &cobra.Command{
 
 		nexusUrl := DEFAULT_NEXUS_URL
 		if url, ok := os.LookupEnv("NEXUS_URL"); ok {
-			nexusUrl = url
+			nexusUrl = strings.TrimRight(url, "/")
 		}
 
-		nexusUrl = fmt.Sprintf("%s/nais/%s/%s/nais.yaml", strings.TrimRight(nexusUrl, "/"),
-			nexusUploadRequest.App, nexusUploadRequest.Version)
+		nexusUrl = fmt.Sprintf("%s/nais/%s/%s/nais.yaml", nexusUrl, nexusUploadRequest.App, nexusUploadRequest.Version)
 
 		req, err := http.NewRequest("PUT", nexusUrl, file)
 		if err != nil {

--- a/cli/cmd/upload.go
+++ b/cli/cmd/upload.go
@@ -1,117 +1,22 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/spf13/cobra"
 	"io/ioutil"
-	"mime/multipart"
 	"net/http"
 	"os"
+	"strings"
 )
 
-const DEFAULT_NEXUS_URL = "http://maven.adeo.no/nexus/service/local/artifact/maven/content"
+const DEFAULT_NEXUS_URL = "http://maven.adeo.no/nexus/content/repositories/m2internal"
 
 type NexusUploadRequest struct {
 	Username string
 	Password string
-	Fields   NexusUploadFields
-}
-
-type NexusUploadFields struct {
-	Repo       string
-	Extension  string
-	GroupId    string
-	ArtifactId string
-	Version    string
-	Packaging  string
-	File       string
-}
-
-func (r NexusUploadRequest) Validate() []error {
-	required := map[string]*string{
-		"Application": &r.Fields.ArtifactId,
-		"Version":     &r.Fields.Version,
-		"Username":    &r.Username,
-		"Password":    &r.Password,
-		"Repo":        &r.Fields.Repo,
-		"Group":       &r.Fields.GroupId,
-		"Packaging":   &r.Fields.Packaging,
-		"Extension":   &r.Fields.Extension,
-		"File":        &r.Fields.File,
-	}
-
-	var errs []error
-	for key, pointer := range required {
-		if len(*pointer) == 0 {
-			errs = append(errs, fmt.Errorf("%s is required and is empty", key))
-		}
-	}
-
-	return errs
-}
-
-func (r NexusUploadFields) WriteFields(w *multipart.Writer) error {
-	if err := w.WriteField("r", r.Repo); err != nil {
-		return err
-	}
-	if err := w.WriteField("hasPom", "false"); err != nil {
-		return err
-	}
-	if err := w.WriteField("e", r.Extension); err != nil {
-		return err
-	}
-	if err := w.WriteField("g", r.GroupId); err != nil {
-		return err
-	}
-	if err := w.WriteField("a", r.ArtifactId); err != nil {
-		return err
-	}
-	if err := w.WriteField("v", r.Version); err != nil {
-		return err
-	}
-	if err := w.WriteField("p", r.Packaging); err != nil {
-		return err
-	}
-	return nil
-}
-
-func readFile(filename string) (os.FileInfo, []byte, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer file.Close()
-	contents, err := ioutil.ReadAll(file)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	fifo, err := file.Stat()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return fifo, contents, nil
-}
-
-func (r NexusUploadFields) WriteFile(w *multipart.Writer) error {
-
-	fifo, contents, err := readFile(r.File)
-	if err != nil {
-		return err
-	}
-
-	part, err := w.CreateFormFile("file", fifo.Name())
-	if err != nil {
-		return err
-	}
-	if _, err := part.Write(contents); err != nil {
-		return err
-	}
-
-	return nil
+	App      string
+	Version  string
+	File     string
 }
 
 var uploadCmd = &cobra.Command{
@@ -122,52 +27,28 @@ var uploadCmd = &cobra.Command{
 		nexusUploadRequest := NexusUploadRequest{
 			Username: os.Getenv("NEXUS_USERNAME"),
 			Password: os.Getenv("NEXUS_PASSWORD"),
-			Fields: NexusUploadFields{
-				Extension: "yaml",
-				Packaging: "yaml",
-			},
 		}
 
-		strings := map[string]*string{
-			"group":    &nexusUploadRequest.Fields.GroupId,
-			"app":      &nexusUploadRequest.Fields.ArtifactId,
-			"version":  &nexusUploadRequest.Fields.Version,
+		opts := map[string]*string{
+			"app":      &nexusUploadRequest.App,
+			"version":  &nexusUploadRequest.Version,
 			"username": &nexusUploadRequest.Username,
 			"password": &nexusUploadRequest.Password,
-			"file":     &nexusUploadRequest.Fields.File,
-			"repo":     &nexusUploadRequest.Fields.Repo,
+			"file":     &nexusUploadRequest.File,
 		}
 
-		for key, pointer := range strings {
+		for key, pointer := range opts {
 			if value, err := cmd.Flags().GetString(key); err != nil {
-				fmt.Printf("Error when getting flag: %s. %v\n", key, err)
+				fmt.Printf("failed getting flag: %s. %v\n", key, err)
 				os.Exit(1)
 			} else if len(value) > 0 {
 				*pointer = value
 			}
 		}
 
-		if err := nexusUploadRequest.Validate(); err != nil {
-			fmt.Printf("NexusUploadRequest is not valid: %v\n", err)
-			os.Exit(1)
-		}
-
-		requestBody := new(bytes.Buffer)
-
-		writer := multipart.NewWriter(requestBody)
-
-		if err := nexusUploadRequest.Fields.WriteFields(writer); err != nil {
-			fmt.Printf("Failed to write fields: %v\n", err)
-			os.Exit(1)
-		}
-
-		if err := nexusUploadRequest.Fields.WriteFile(writer); err != nil {
-			fmt.Printf("Failed to write file: %v\n", err)
-			os.Exit(1)
-		}
-
-		if err := writer.Close(); err != nil {
-			fmt.Printf("Failed to close writer: %v\n", err)
+		file, err := os.Open(nexusUploadRequest.File)
+		if err != nil {
+			fmt.Printf("failed to open file: %v\n", err)
 			os.Exit(1)
 		}
 
@@ -176,20 +57,22 @@ var uploadCmd = &cobra.Command{
 			nexusUrl = url
 		}
 
-		req, err := http.NewRequest("POST", nexusUrl, requestBody)
+		nexusUrl = fmt.Sprintf("%s/nais/%s/%s/nais.yaml", strings.TrimRight(nexusUrl, "/"),
+			nexusUploadRequest.App, nexusUploadRequest.Version)
+
+		req, err := http.NewRequest("PUT", nexusUrl, file)
 		if err != nil {
-			fmt.Printf("Failed to create http request: %v\n", err)
+			fmt.Printf("failed to create http request: %v\n", err)
 			os.Exit(1)
 		}
 
-		req.Header.Set("Content-Type", writer.FormDataContentType())
 		req.SetBasicAuth(nexusUploadRequest.Username, nexusUploadRequest.Password)
 
 		client := &http.Client{}
 		resp, err := client.Do(req)
 
 		if err != nil {
-			fmt.Printf("Error while sending POST request: %v\n", err)
+			fmt.Printf("error while uploading file: %v\n", err)
 			os.Exit(1)
 		}
 		defer resp.Body.Close()
@@ -209,8 +92,6 @@ func init() {
 
 	uploadCmd.Flags().StringP("app", "a", "", "name of your app")
 	uploadCmd.Flags().StringP("version", "v", "", "version you want to upload")
-	uploadCmd.Flags().StringP("repo", "r", "m2internal", "nexus repo")
-	uploadCmd.Flags().StringP("group", "g", "nais", "nexus group")
 	uploadCmd.Flags().StringP("file", "f", "nais.yaml", "path to nais.yaml")
 	uploadCmd.Flags().StringP("username", "u", "", "the username")
 	uploadCmd.Flags().StringP("password", "p", "", "the password")


### PR DESCRIPTION
Don't know if we should set `repo.adeo.no` as the default Nexus, or keep the `maven.adeo.no` for backwards compatibility? Should `repo.adeo.no` be set using a flag instead of env var (or both)?