### PR TITLE
NAIS env password prompt and secret resolving

### DIFF
--- a/api/fasit.go
+++ b/api/fasit.go
@@ -112,8 +112,12 @@ type NaisResource struct {
 	ingresses    map[string]string
 }
 
-func (nr NaisResource) GetProperties() map[string]string {
+func (nr NaisResource) Properties() map[string]string {
 	return nr.properties
+}
+
+func (nr NaisResource) Secret() map[string]string {
+	return nr.secret
 }
 
 func (nr NaisResource) ToEnvironmentVariable(property string) string {

--- a/cli/cmd/environment.go
+++ b/cli/cmd/environment.go
@@ -129,7 +129,11 @@ Or just save it to a file
 		formattedVars := make([]string, 0)
 
 		for _, resource := range vars {
-			for key, val := range resource.GetProperties() {
+			for key, val := range resource.Secret() {
+				environmentVariable := resource.ToEnvironmentVariable(key)
+				formattedVars = append(formattedVars, fmt.Sprintf(stringFormat, environmentVariable, val))
+			}
+			for key, val := range resource.Properties() {
 				environmentVariable := resource.ToEnvironmentVariable(key)
 				formattedVars = append(formattedVars, fmt.Sprintf(stringFormat, environmentVariable, val))
 			}

--- a/cli/cmd/environment.go
+++ b/cli/cmd/environment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"strings"
 	"syscall"
 
@@ -34,9 +35,13 @@ Or just save it to a file
 		username := os.Getenv("FASIT_USERNAME")
 		password := os.Getenv("FASIT_PASSWORD")
 
-		// Fall back to the username of the logged in user
 		if username == "" {
-			username = os.Getenv("USER")
+			currentUser, err := user.Current()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Unable resolve a username, please specify FASIT_USERNAME")
+				os.Exit(1)
+			}
+			username = currentUser.Username
 		}
 
 		if password == "" {

--- a/cli/cmd/environment.go
+++ b/cli/cmd/environment.go
@@ -5,6 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"syscall"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/nais/naisd/api"
 	"github.com/spf13/cobra"
@@ -30,6 +33,22 @@ Or just save it to a file
 		application := args[0]
 		username := os.Getenv("FASIT_USERNAME")
 		password := os.Getenv("FASIT_PASSWORD")
+
+		// Fall back to the ident of the logged in user
+		if username == "" {
+			username = os.Getenv("USER")
+		}
+
+		if password == "" {
+			fmt.Fprintf(os.Stderr, "Enter ident password: ")
+			passwordBytes, err := terminal.ReadPassword(int(syscall.Stdin))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error occurred while trying to read password from stdin\n")
+				os.Exit(1)
+			}
+			password = string(passwordBytes)
+			fmt.Fprintln(os.Stderr)
+		}
 
 		inline := true
 

--- a/cli/cmd/environment.go
+++ b/cli/cmd/environment.go
@@ -34,13 +34,13 @@ Or just save it to a file
 		username := os.Getenv("FASIT_USERNAME")
 		password := os.Getenv("FASIT_PASSWORD")
 
-		// Fall back to the ident of the logged in user
+		// Fall back to the username of the logged in user
 		if username == "" {
 			username = os.Getenv("USER")
 		}
 
 		if password == "" {
-			fmt.Fprintf(os.Stderr, "Enter ident password: ")
+			fmt.Fprintf(os.Stderr, "Enter password for %s: ", username)
 			passwordBytes, err := terminal.ReadPassword(int(syscall.Stdin))
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error occurred while trying to read password from stdin\n")

--- a/cli/cmd/environment_test.go
+++ b/cli/cmd/environment_test.go
@@ -21,6 +21,7 @@ var expected_vars = map[string]string{
 }
 
 func runCommand(t *testing.T, args []string) ([]byte, int) {
+	os.Setenv("FASIT_PASSWORD", "mockPassword")
 	defer gock.Off()
 
 	gock.New("https://fasit.local").


### PR DESCRIPTION
To avoid having to  save your password as an environment variable I've made it possible to prompt for password. The command will now also fall back to using the $USER environment variable, when this should be enough for most use cases.

The other commit adds support for resolving secrets from fasit.