### PR TITLE
Make sure certificate env vars are created the same way as others

### DIFF
--- a/api/fasit_test.go
+++ b/api/fasit_test.go
@@ -215,7 +215,7 @@ func TestUpdateResource(t *testing.T) {
 		assert.Error(t, err)
 	})
 	gock.New("https://fasit.local").
-		Put("/api/v2/resources/" + fmt.Sprint(naisResource.id)).
+		Put("/api/v2/resources/"+fmt.Sprint(naisResource.id)).
 		HeaderPresent("Authorization").
 		MatchHeader("Content-Type", "application/json").
 		Reply(200)
@@ -227,7 +227,7 @@ func TestUpdateResource(t *testing.T) {
 		assert.Equal(t, naisResource.id, createdResourceId)
 	})
 	gock.New("https://fasit.local").
-		Put("/api/v2/resources/" + fmt.Sprint(naisResource.id)).
+		Put("/api/v2/resources/"+fmt.Sprint(naisResource.id)).
 		HeaderPresent("Authorization").
 		HeaderPresent("x-onbehalfof").
 		MatchHeader("Content-Type", "application/json").
@@ -245,7 +245,7 @@ func TestUpdateResource(t *testing.T) {
 		assert.Equal(t, naisResource.id, createdResourceId)
 	})
 	gock.New("https://fasit.local").
-		Put("/api/v2/resources/" + fmt.Sprint(naisResource.id)).
+		Put("/api/v2/resources/"+fmt.Sprint(naisResource.id)).
 		HeaderPresent("Authorization").
 		MatchHeader("Content-Type", "application/json").
 		Reply(501).
@@ -809,7 +809,7 @@ func TestResolveCertificates(t *testing.T) {
 
 		assert.Nil(t, appError)
 
-		assert.Equal(t, "Some binary format", string(resource.certificates["srvvarseloppgave_cert_keystore"]))
+		assert.Equal(t, "Some binary format", string(resource.certificates["keystore"]))
 
 	})
 


### PR DESCRIPTION
When certificates are resolved the resource alias is used to create the key name:
https://github.com/nais/naisd/blob/d18bd5cad61c2efcd853b38b59a1e458b562edd8/api/fasit.go#L579

When the environment variables for the certificates are created, the resource alias is prepended once again (because of `res.ToEnvironmentVariable()`:
https://github.com/nais/naisd/blob/d18bd5cad61c2efcd853b38b59a1e458b562edd8/api/resourcecreator.go#L340 
A certificate aliased `my_trustore` with a certificate file called `keystore`, would end up being defined as `MY_TRUSTSTORE_MY_TRUSTORE_KEYSTORE_PATH`.

This pull normalizes the naming so we only prepend the resource alias once.