### PR TITLE
Remove hardcoded _PATH-suffix

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -10,7 +10,7 @@ func DefaultResourceRequests() []ResourceRequest {
 		{
 			Alias:        NavTruststoreFasitAlias,
 			ResourceType: "certificate",
-			PropertyMap:  map[string]string{"keystore": "NAV_TRUSTSTORE"},
+			PropertyMap:  map[string]string{"keystore": "NAV_TRUSTSTORE_PATH"},
 		},
 	}
 }
@@ -19,8 +19,8 @@ func GetDefaultManifest(application string) NaisManifest {
 
 	defaultManifest := NaisManifest{
 		Replicas: Replicas{
-			Min:                    2,
-			Max:                    4,
+			Min: 2,
+			Max: 4,
 			CpuThresholdPercentage: 50,
 		},
 		Port: 8080,

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -337,7 +337,7 @@ func createEnvironmentVariables(deploymentRequest NaisDeploymentRequest, naisRes
 		if res.certificates != nil {
 			for k := range res.certificates {
 				envVar := k8score.EnvVar{
-					Name:  res.ToEnvironmentVariable(k)+"_PATH",
+					Name:  res.ToEnvironmentVariable(k),
 					Value: "/var/run/secrets/naisd.io/" + res.ToResourceVariable(k),
 				}
 

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -435,9 +435,9 @@ func TestDeployment(t *testing.T) {
 		envVars := deployment.Spec.Template.Spec.Containers[0].Env
 
 		assert.Equal(t, 9, len(envVars))
-		assert.Equal(t, "R1_CERT1KEY_PATH", envVars[5].Name)
+		assert.Equal(t, "R1_CERT1KEY", envVars[5].Name)
 		assert.Equal(t, "/var/run/secrets/naisd.io/r1_cert1key", envVars[5].Value)
-		assert.Equal(t, "R2_CERT2KEY_PATH", envVars[8].Name)
+		assert.Equal(t, "R2_CERT2KEY", envVars[8].Name)
 		assert.Equal(t, "/var/run/secrets/naisd.io/r2_cert2key", envVars[8].Value)
 
 	})


### PR DESCRIPTION
* `NAV_TRUSTSTORE_PATH` remains the same
* Path to all other certificates will be on the form `<ALIAS>_KEYSTORE`. If they want/need the `_PATH`-suffix this can easily be fixed using `propertyMap` (which is what we are using to set `NAV_TRUSTSTORE_PATH`)