### PR TITLE
Enhance deploy cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ nais deploy [flags]
 Flags:
   -a, --app string            name of your app
   -c, --cluster string        the cluster you want to deploy to (default: "preprod-fss")
-  -e, --environment string    environment you want to use (default "t0")
+  -e, --environment string    environment you want to use (default "q0")
   -m, --manifest-url string   alternative URL to the nais manifest
   -n, --namespace string      the kubernetes namespace (default "default")
-  -p, --password string       the password
-  -u, --username string       the username
+  -p, --fasit-password string the password
+  -u, --fasit-username string the username
   -v, --version string        version you want to deploy
       --wait                  whether to wait until the deploy has succeeded (or failed)
   -z, --zone string           the zone the app will be in (default "fss")
 ```
 
-If using default values, only `app`, `version`, `username` and `password` is required.
+If using default values, only `app`, `version`, `fasit-username` and `fasit-password` is required.
 
-The username and password may be specified using environment variable `NAIS_USERNAME` and `NAIS_PASSWORD` instead.
+The username and password may be specified using environment variable `FASIT_USERNAME` and `FASIT_PASSWORD` instead.
 
 
 ### Installation

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -74,6 +74,24 @@ var deployCmd = &cobra.Command{
 			FasitPassword: os.Getenv("FASIT_PASSWORD"),
 		}
 
+		if deployRequest.FasitUsername == "" {
+			deployRequest.FasitUsername = os.Getenv("NAIS_USERNAME")
+
+			if deployRequest.FasitUsername != "" {
+				fmt.Fprintf(os.Stderr, "Deprecation warning: NAIS_USERNAME is replaced by FASIT_USERNAME.\n" +
+					"It will be removed in future versions.\n")
+			}
+		}
+
+		if deployRequest.FasitPassword == "" {
+			deployRequest.FasitPassword = os.Getenv("NAIS_PASSWORD")
+
+			if deployRequest.FasitPassword != "" {
+				fmt.Fprintf(os.Stderr, "Deprecation warning: NAIS_PASSWORD is replaced by FASIT_PASSWORD.\n" +
+					"It will be removed in future versions.\n")
+			}
+		}
+
 		var cluster string
 		strings := map[string]*string{
 			"app":               &deployRequest.Application,


### PR DESCRIPTION
* Fallback to `USER` if username is empty
* change env var from `NAIS_` to `FASIT_` to avoid confusion (breaks BC)
* default environment is changed from `t0` to `q0` (breaks BC)