### PR TITLE
   Refactor NaisDeploymentRequest -> Deploy

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/nais/naisd/api/naisrequest"
 	"github.com/stretchr/testify/assert"
 	"goji.io"
 	"goji.io/pat"
@@ -105,7 +106,7 @@ func TestNoManifestGivesError(t *testing.T) {
 	api := Api{}
 
 	manifestUrl := "http://repo.com/app"
-	depReq := NaisDeploymentRequest{
+	depReq := naisrequest.Deploy{
 		Application:      "appname",
 		Version:          "",
 		FasitEnvironment: "",
@@ -153,7 +154,7 @@ func TestValidDeploymentRequestAndManifestCreateResources(t *testing.T) {
 
 	api := Api{clientset, "https://fasit.local", "nais.example.tk", "test-cluster", false, nil}
 
-	depReq := NaisDeploymentRequest{
+	depReq := naisrequest.Deploy{
 		Application:      appName,
 		Version:          version,
 		FasitEnvironment: environment,
@@ -242,7 +243,7 @@ func TestValidDeploymentRequestAndManifestCreateAlerts(t *testing.T) {
 
 	api := Api{clientset, "https://fasit.local", "nais.example.tk", "test-cluster", false, nil}
 
-	depReq := NaisDeploymentRequest{
+	depReq := naisrequest.Deploy{
 		Application:      appName,
 		Version:          version,
 		FasitEnvironment: environment,
@@ -349,7 +350,7 @@ func TestMissingResources(t *testing.T) {
 }
 
 func CreateDefaultDeploymentRequest() string {
-	jsn, _ := json.Marshal(NaisDeploymentRequest{
+	jsn, _ := json.Marshal(naisrequest.Deploy{
 		Application:      "appname",
 		Version:          "123",
 		FasitEnvironment: "namespace",
@@ -363,7 +364,7 @@ func CreateDefaultDeploymentRequest() string {
 
 func TestValidateDeploymentRequest(t *testing.T) {
 	t.Run("Empty fields should be marked invalid", func(t *testing.T) {
-		invalid := NaisDeploymentRequest{
+		invalid := naisrequest.Deploy{
 			Application:      "",
 			Version:          "",
 			FasitEnvironment: "",

--- a/api/const.go
+++ b/api/const.go
@@ -1,7 +1,0 @@
-package api
-
-const ZONE_SBS = "sbs"
-const ZONE_IAPP = "iapp"
-const ZONE_FSS = "fss"
-
-const ENVIRONMENT_P = "p"

--- a/api/constant/constant.go
+++ b/api/constant/constant.go
@@ -1,0 +1,8 @@
+package constant
+
+const (
+	ZONE_SBS      = "sbs"
+	ZONE_IAPP     = "iapp"
+	ZONE_FSS      = "fss"
+	ENVIRONMENT_P = "p"
+)

--- a/api/fasit_test.go
+++ b/api/fasit_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nais/naisd/api/constant"
+	"github.com/nais/naisd/api/naisrequest"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
 )
@@ -18,7 +20,7 @@ func TestResourceEnvironmentVariableName(t *testing.T) {
 			1,
 			"test.resource",
 			"type",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{},
 			map[string]string{},
 			map[string]string{},
@@ -32,7 +34,7 @@ func TestResourceEnvironmentVariableName(t *testing.T) {
 			1,
 			"test.resource",
 			"applicationproperties",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{
 				"foo.var-with.mixed_stuff": "fizz",
 			},
@@ -50,7 +52,7 @@ func TestResourceEnvironmentVariableName(t *testing.T) {
 			1,
 			"test.resource",
 			"applicationproperties",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{
 				"foo.var-with.mixed_stuff": "fizz",
 			},
@@ -68,7 +70,7 @@ func TestResourceEnvironmentVariableName(t *testing.T) {
 			1,
 			"test.resource",
 			"datasource",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{
 				"url":      "fizzbuzz",
 				"username": "fizz",
@@ -135,7 +137,7 @@ func TestCreatingApplicationInstance(t *testing.T) {
 
 	fasit := FasitClient{"https://fasit.local", "", ""}
 	exposedResourceIds, usedResourceIds := []int{1, 2, 3}, []int{4, 5, 6}
-	deploymentRequest := NaisDeploymentRequest{Application: "app", FasitEnvironment: "env", Version: "123"}
+	deploymentRequest := naisrequest.Deploy{Application: "app", FasitEnvironment: "env", Version: "123"}
 
 	t.Run("A valid payload creates ApplicationInstance", func(t *testing.T) {
 		err := fasit.createApplicationInstance(deploymentRequest, "", "", exposedResourceIds, usedResourceIds)
@@ -153,7 +155,7 @@ func TestCreatingResource(t *testing.T) {
 		ResourceType: "RestService",
 		Path:         "",
 	}
-	deploymentRequest := NaisDeploymentRequest{
+	deploymentRequest := naisrequest.Deploy{
 		Application: "application",
 		Zone:        "zone",
 	}
@@ -200,7 +202,7 @@ func TestUpdateResource(t *testing.T) {
 		ResourceType: "RestService",
 		Path:         "",
 	}
-	deploymentRequest := NaisDeploymentRequest{
+	deploymentRequest := naisrequest.Deploy{
 		Application: "application",
 		Zone:        "zone",
 	}
@@ -304,7 +306,7 @@ func (fasit FakeFasitClient) getScopedResource(resourcesRequest ResourceRequest,
 	}
 }
 
-func (fasit FakeFasitClient) createResource(resource ExposedResource, fasitEnvironmentClass, environment, hostname string, deploymentRequest NaisDeploymentRequest) (int, error) {
+func (fasit FakeFasitClient) createResource(resource ExposedResource, fasitEnvironmentClass, environment, hostname string, deploymentRequest naisrequest.Deploy) (int, error) {
 	switch deploymentRequest.Zone {
 	case "failed":
 		return 0, fmt.Errorf("random error")
@@ -315,7 +317,7 @@ func (fasit FakeFasitClient) createResource(resource ExposedResource, fasitEnvir
 
 var updateCalled bool
 
-func (fasit FakeFasitClient) updateResource(existingResource NaisResource, resource ExposedResource, fasitEnvironmentClass, environment, hostname string, deploymentRequest NaisDeploymentRequest) (int, error) {
+func (fasit FakeFasitClient) updateResource(existingResource NaisResource, resource ExposedResource, fasitEnvironmentClass, environment, hostname string, deploymentRequest naisrequest.Deploy) (int, error) {
 	updateCalled = true
 	switch deploymentRequest.Zone {
 	case "failed":
@@ -328,7 +330,7 @@ func (fasit FakeFasitClient) updateResource(existingResource NaisResource, resou
 
 var createApplicationInstanceCalled bool
 
-func (fasit FakeFasitClient) createApplicationInstance(deploymentRequest NaisDeploymentRequest, fasitEnvironment, subDomain string, exposedResourceIds, usedResourceIds []int) error {
+func (fasit FakeFasitClient) createApplicationInstance(deploymentRequest naisrequest.Deploy, fasitEnvironment, subDomain string, exposedResourceIds, usedResourceIds []int) error {
 	createApplicationInstanceCalled = true
 	return nil
 }
@@ -347,7 +349,7 @@ func TestCreateOrUpdateFasitResources(t *testing.T) {
 		Path:         "",
 	}
 
-	deploymentRequest := NaisDeploymentRequest{
+	deploymentRequest := naisrequest.Deploy{
 		Application: "application",
 		Zone:        "zone",
 	}
@@ -437,7 +439,7 @@ func TestUpdateFasit(t *testing.T) {
 	usedResources := []NaisResource{{id: 1}, {id: 2}}
 	exposedResources := []ExposedResource{exposedResource, exposedResource}
 
-	deploymentRequest := NaisDeploymentRequest{
+	deploymentRequest := naisrequest.Deploy{
 		Application:      application,
 		FasitEnvironment: environment,
 		Version:          version,
@@ -476,7 +478,7 @@ func TestBuildingFasitPayloads(t *testing.T) {
 	version := "2.1"
 	exposedResourceIds := []int{1, 2, 3}
 	usedResourceIds := []int{4, 5, 6}
-	zone := ZONE_FSS
+	zone := constant.ZONE_FSS
 	alias := "resourceAlias"
 	path := "/myPath"
 	hostname := "hostname"
@@ -487,7 +489,7 @@ func TestBuildingFasitPayloads(t *testing.T) {
 	description := "myDescription"
 	wsdlPath := fmt.Sprintf("http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?a=%s&e=zip&g=%s&r=m2internal&v=%s", wsdlArtifactId, wsdlGroupId, version)
 
-	deploymentRequest := NaisDeploymentRequest{
+	deploymentRequest := naisrequest.Deploy{
 		Application:      application,
 		FasitEnvironment: environment,
 		Version:          version,
@@ -509,8 +511,8 @@ func TestBuildingFasitPayloads(t *testing.T) {
 		SecurityToken:  securityToken,
 		Description:    description,
 	}
-	exposedResources := []Resource{Resource{1}, Resource{2}, Resource{3}}
-	usedResources := []Resource{Resource{4}, Resource{5}, Resource{6}}
+	exposedResources := []Resource{{1}, {2}, {3}}
+	usedResources := []Resource{{4}, {5}, {6}}
 
 	t.Run("Building ApplicationInstancePayload", func(t *testing.T) {
 		payload := buildApplicationInstancePayload(deploymentRequest, fasitEnvironment, subDomain, exposedResourceIds, usedResourceIds)
@@ -588,7 +590,7 @@ func TestGenerateScope(t *testing.T) {
 	existingResource := NaisResource{}
 	fasitEnvironmentClass := "u"
 	environment := "u1"
-	zone := ZONE_FSS
+	zone := constant.ZONE_FSS
 	t.Run("default scope set when creating a resource", func(t *testing.T) {
 		scope := generateScope(resource, existingResource, fasitEnvironmentClass, environment, zone)
 		defaultScope := Scope{EnvironmentClass: fasitEnvironmentClass, Environment: environment, Zone: zone}

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -3,13 +3,14 @@ package api
 import (
 	"fmt"
 	"github.com/golang/glog"
+	"github.com/hashicorp/go-multierror"
 	"github.com/imdario/mergo"
+	"github.com/nais/naisd/api/naisrequest"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
-	"github.com/hashicorp/go-multierror"
 )
 
 type Probe struct {
@@ -50,7 +51,7 @@ type NaisManifest struct {
 	Image           string
 	Port            int
 	Healthcheck     Healthcheck
-	PreStopHookPath string         `yaml:"preStopHookPath"`
+	PreStopHookPath string `yaml:"preStopHookPath"`
 	Prometheus      PrometheusConfig
 	Istio           IstioConfig
 	Replicas        Replicas
@@ -109,7 +110,7 @@ type Field struct {
 	Value string
 }
 
-func GenerateManifest(deploymentRequest NaisDeploymentRequest) (naisManifest NaisManifest, err error) {
+func GenerateManifest(deploymentRequest naisrequest.Deploy) (naisManifest NaisManifest, err error) {
 
 	manifest, err := downloadManifest(deploymentRequest)
 
@@ -132,7 +133,7 @@ func GenerateManifest(deploymentRequest NaisDeploymentRequest) (naisManifest Nai
 	return manifest, nil
 }
 
-func downloadManifest(deploymentRequest NaisDeploymentRequest) (naisManifest NaisManifest, err error) {
+func downloadManifest(deploymentRequest naisrequest.Deploy) (naisManifest NaisManifest, err error) {
 
 	var urls []string
 	var errors error

--- a/api/naisrequest/deploy.go
+++ b/api/naisrequest/deploy.go
@@ -1,0 +1,44 @@
+package naisrequest
+
+import (
+	"errors"
+	"fmt"
+	"github.com/nais/naisd/api/constant"
+)
+
+type Deploy struct {
+	Application      string `json:"application"`
+	Version          string `json:"version"`
+	Zone             string `json:"zone"`
+	ManifestUrl      string `json:"manifesturl,omitempty"`
+	FasitEnvironment string `json:"fasitEnvironment"`
+	FasitUsername    string `json:"fasitUsername"`
+	FasitPassword    string `json:"fasitPassword"`
+	OnBehalfOf       string `json:"onbehalfof,omitempty"`
+	Namespace        string `json:"namespace"`
+}
+
+func (r Deploy) Validate() []error {
+	required := map[string]*string{
+		"application":      &r.Application,
+		"version":          &r.Version,
+		"fasitEnvironment": &r.FasitEnvironment,
+		"zone":             &r.Zone,
+		"fasitUsername":    &r.FasitUsername,
+		"fasitPassword":    &r.FasitPassword,
+		"namespace":        &r.Namespace,
+	}
+
+	var errs []error
+	for key, pointer := range required {
+		if len(*pointer) == 0 {
+			errs = append(errs, fmt.Errorf("%s is required and is empty", key))
+		}
+	}
+
+	if r.Zone != constant.ZONE_FSS && r.Zone != constant.ZONE_SBS && r.Zone != constant.ZONE_IAPP {
+		errs = append(errs, errors.New("zone can only be fss, sbs or iapp"))
+	}
+
+	return errs
+}

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"github.com/golang/glog"
+	"github.com/nais/naisd/api/naisrequest"
 	"gopkg.in/yaml.v2"
 	k8score "k8s.io/api/core/v1"
 )
@@ -54,7 +55,7 @@ func createDeploymentPrefix(namespace string, deployName string) string {
 	return namespace + "-" + deployName
 }
 
-func addRulesToConfigMap(configMap *k8score.ConfigMap, deploymentRequest NaisDeploymentRequest, manifest NaisManifest) (*k8score.ConfigMap, error) {
+func addRulesToConfigMap(configMap *k8score.ConfigMap, deploymentRequest naisrequest.Deploy, manifest NaisManifest) (*k8score.ConfigMap, error) {
 	deploymentPrefix := createDeploymentPrefix(deploymentRequest.Namespace, deploymentRequest.Application)
 
 	addTeamLabel(manifest.Alerts, manifest.Team)

--- a/api/prometheus_test.go
+++ b/api/prometheus_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/nais/naisd/api/naisrequest"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	"k8s.io/api/core/v1"
@@ -84,7 +85,7 @@ func TestAddRulesToConfigMap(t *testing.T) {
 		},
 	}
 
-	deploymentRequest := NaisDeploymentRequest{
+	deploymentRequest := naisrequest.Deploy{
 		Application: appName,
 		Namespace:   namespace,
 	}

--- a/api/redis.go
+++ b/api/redis.go
@@ -2,20 +2,22 @@ package api
 
 import (
 	"fmt"
+	"github.com/nais/naisd/api/constant"
+	"github.com/nais/naisd/api/naisrequest"
+	redisapi "github.com/spotahome/redis-operator/api/redisfailover/v1alpha2"
+	redisclient "github.com/spotahome/redis-operator/client/k8s/clientset/versioned/typed/redisfailover/v1alpha2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srest "k8s.io/client-go/rest"
-	redisapi "github.com/spotahome/redis-operator/api/redisfailover/v1alpha2"
-	redisclient "github.com/spotahome/redis-operator/client/k8s/clientset/versioned/typed/redisfailover/v1alpha2"
 )
 
-func createRedisFailoverDef(deploymentRequest NaisDeploymentRequest, team string) *redisapi.RedisFailover {
+func createRedisFailoverDef(deploymentRequest naisrequest.Deploy, team string) *redisapi.RedisFailover {
 	replicas := int32(3)
 	resources := redisapi.RedisFailoverResources{
 		Limits:   redisapi.CPUAndMem{Memory: "100Mi"},
 		Requests: redisapi.CPUAndMem{CPU: "100m"},
 	}
-	if deploymentRequest.FasitEnvironment != ENVIRONMENT_P {
+	if deploymentRequest.FasitEnvironment != constant.ENVIRONMENT_P {
 		replicas = int32(1)
 		resources = redisapi.RedisFailoverResources{
 			Limits:   redisapi.CPUAndMem{Memory: "50Mi"},
@@ -53,7 +55,7 @@ func getExistingFailover(failoverInterface redisclient.RedisFailoverInterface, a
 	}
 }
 
-func updateOrCreateRedisSentinelCluster(deploymentRequest NaisDeploymentRequest, team string) (*redisapi.RedisFailover, error) {
+func updateOrCreateRedisSentinelCluster(deploymentRequest naisrequest.Deploy, team string) (*redisapi.RedisFailover, error) {
 	newFailover := createRedisFailoverDef(deploymentRequest, team)
 
 	config, err := k8srest.InClusterConfig()

--- a/api/redis_test.go
+++ b/api/redis_test.go
@@ -1,13 +1,15 @@
 package api
 
 import (
-	"testing"
+	"github.com/nais/naisd/api/constant"
+	"github.com/nais/naisd/api/naisrequest"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestRedisResource(t *testing.T) {
 	t.Run("Replicas should be 1 when not prod", func(t *testing.T) {
-		deploymentRequest := NaisDeploymentRequest{
+		deploymentRequest := naisrequest.Deploy{
 			Application:      "redisTest",
 			FasitEnvironment: "t",
 			Namespace:        "default",
@@ -17,9 +19,9 @@ func TestRedisResource(t *testing.T) {
 	})
 
 	t.Run("Replicas should be 3 when prod", func(t *testing.T) {
-		deploymentRequest := NaisDeploymentRequest{
+		deploymentRequest := naisrequest.Deploy{
 			Application:      "redisTest",
-			FasitEnvironment: ENVIRONMENT_P,
+			FasitEnvironment: constant.ENVIRONMENT_P,
 			Namespace:        "default",
 		}
 		redisFailoverDef := createRedisFailoverDef(deploymentRequest, "teamBeam")

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"github.com/nais/naisd/api/constant"
+	"github.com/nais/naisd/api/naisrequest"
 	"github.com/stretchr/testify/assert"
 	k8score "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -65,7 +67,7 @@ func newDefaultManifest() NaisManifest {
 			Enabled: true,
 		},
 		LeaderElection: false,
-		Redis: false,
+		Redis:          false,
 	}
 
 	return manifest
@@ -90,7 +92,7 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("when no service exists, a new one is created", func(t *testing.T) {
-		service, err := createService(NaisDeploymentRequest{Namespace: namespace, Application: otherAppName, Version: version}, otherTeamName, clientset)
+		service, err := createService(naisrequest.Deploy{Namespace: namespace, Application: otherAppName, Version: version}, otherTeamName, clientset)
 
 		assert.NoError(t, err)
 		assert.Equal(t, otherAppName, service.ObjectMeta.Name)
@@ -100,7 +102,7 @@ func TestService(t *testing.T) {
 		assert.Equal(t, map[string]string{"app": otherAppName}, service.Spec.Selector)
 	})
 	t.Run("when service exists, nothing happens", func(t *testing.T) {
-		nilValue, err := createService(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, teamName, clientset)
+		nilValue, err := createService(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, teamName, clientset)
 		assert.NoError(t, err)
 		assert.Nil(t, nilValue)
 	})
@@ -146,7 +148,7 @@ func TestDeployment(t *testing.T) {
 			1,
 			resource1Name,
 			resource1Type,
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{resource1Key: resource1Value},
 			map[string]string{},
 			map[string]string{secret1Key: secret1Value},
@@ -157,7 +159,7 @@ func TestDeployment(t *testing.T) {
 			1,
 			resource2Name,
 			resource2Type,
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{resource2Key: resource2Value},
 			map[string]string{
 				resource2Key: resource2KeyMapping,
@@ -170,7 +172,7 @@ func TestDeployment(t *testing.T) {
 			1,
 			"resource3",
 			"applicationproperties",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{
 				"key1": "value1",
 			},
@@ -183,7 +185,7 @@ func TestDeployment(t *testing.T) {
 			1,
 			"resource4",
 			"applicationproperties",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{
 				"key2.Property": "dc=preprod,dc=local",
 			},
@@ -196,7 +198,7 @@ func TestDeployment(t *testing.T) {
 			1,
 			invalidlyNamedResourceNameDot,
 			invalidlyNamedResourceTypeDot,
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{invalidlyNamedResourceKeyDot: invalidlyNamedResourceValueDot},
 			map[string]string{},
 			map[string]string{invalidlyNamedResourceSecretKeyDot: invalidlyNamedResourceSecretValueDot},
@@ -207,7 +209,7 @@ func TestDeployment(t *testing.T) {
 			1,
 			invalidlyNamedResourceNameColon,
 			invalidlyNamedResourceTypeColon,
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{invalidlyNamedResourceKeyColon: invalidlyNamedResourceValueColon},
 			map[string]string{},
 			map[string]string{invalidlyNamedResourceSecretKeyColon: invalidlyNamedResourceSecretValueColon},
@@ -221,7 +223,7 @@ func TestDeployment(t *testing.T) {
 			1,
 			resource1Name,
 			"certificate",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{resource1Key: resource1Value},
 			map[string]string{},
 			map[string]string{secret1Key: secret1Value},
@@ -232,7 +234,7 @@ func TestDeployment(t *testing.T) {
 			1,
 			resource2Name,
 			resource2Type,
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{resource2Key: resource2Value},
 			map[string]string{
 				resource2Key: resource2KeyMapping,
@@ -243,7 +245,7 @@ func TestDeployment(t *testing.T) {
 		},
 	}
 
-	deployment, err := createDeploymentDef(naisResources, newDefaultManifest(), NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, nil, false)
+	deployment, err := createDeploymentDef(naisResources, newDefaultManifest(), naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, nil, false)
 
 	assert.Nil(t, err)
 
@@ -266,7 +268,7 @@ func TestDeployment(t *testing.T) {
 	t.Run("when no deployment exists, it's created", func(t *testing.T) {
 		manifest := newDefaultManifest()
 		manifest.Istio.Enabled = true
-		deployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: otherAppName, Version: version, FasitEnvironment: environment}, manifest, naisResources, true, clientset)
+		deployment, err := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: otherAppName, Version: version, FasitEnvironment: environment}, manifest, naisResources, true, clientset)
 
 		assert.NoError(t, err)
 		assert.Equal(t, otherAppName, deployment.Name)
@@ -332,7 +334,7 @@ func TestDeployment(t *testing.T) {
 	})
 
 	t.Run("when a deployment exists, its updated", func(t *testing.T) {
-		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: newVersion}, newDefaultManifest(), naisResources, false, clientset)
+		updatedDeployment, err := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: newVersion}, newDefaultManifest(), naisResources, false, clientset)
 		assert.NoError(t, err)
 
 		assert.Equal(t, resourceVersion, deployment.ObjectMeta.ResourceVersion)
@@ -347,7 +349,7 @@ func TestDeployment(t *testing.T) {
 	t.Run("when leaderElection is true, extra container exists", func(t *testing.T) {
 		manifest := newDefaultManifest()
 		manifest.LeaderElection = true
-		deployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, manifest, naisResources, false, clientset)
+		deployment, err := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, manifest, naisResources, false, clientset)
 		assert.NoError(t, err)
 
 		containers := deployment.Spec.Template.Spec.Containers
@@ -363,7 +365,7 @@ func TestDeployment(t *testing.T) {
 		manifest.Prometheus.Path = "/newPath"
 		manifest.Prometheus.Enabled = false
 
-		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, manifest, naisResources, false, clientset)
+		updatedDeployment, err := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, manifest, naisResources, false, clientset)
 		assert.NoError(t, err)
 
 		assert.Equal(t, map[string]string{
@@ -379,7 +381,7 @@ func TestDeployment(t *testing.T) {
 		manifest := newDefaultManifest()
 		manifest.PreStopHookPath = path
 
-		d, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, manifest, naisResources, false, clientset)
+		d, err := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, manifest, naisResources, false, clientset)
 		assert.NoError(t, err)
 		assert.Equal(t, path, d.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.HTTPGet.Path)
 		assert.Equal(t, intstr.FromString(DefaultPortName), d.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.HTTPGet.Port)
@@ -396,7 +398,7 @@ func TestDeployment(t *testing.T) {
 				1,
 				resource1Name,
 				resource1Type,
-				Scope{"u", "u1", ZONE_FSS},
+				Scope{"u", "u1", constant.ZONE_FSS},
 				nil,
 				nil,
 				nil,
@@ -405,7 +407,7 @@ func TestDeployment(t *testing.T) {
 			},
 		}
 
-		updatedDeployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, newDefaultManifest(), updatedResource, false, clientset)
+		updatedDeployment, err := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, newDefaultManifest(), updatedResource, false, clientset)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 1, len(updatedDeployment.Spec.Template.Spec.Volumes))
@@ -419,7 +421,7 @@ func TestDeployment(t *testing.T) {
 	})
 
 	t.Run("File secrets are mounted correctly for a new deployment", func(t *testing.T) {
-		deployment, _ := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, newDefaultManifest(), naisCertResources, false, clientset)
+		deployment, _ := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, newDefaultManifest(), naisCertResources, false, clientset)
 
 		assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Volumes))
 		assert.Equal(t, appName, deployment.Spec.Template.Spec.Volumes[0].Name)
@@ -436,7 +438,7 @@ func TestDeployment(t *testing.T) {
 	})
 
 	t.Run("Env variable is created for file secrets ", func(t *testing.T) {
-		deployment, _ := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, newDefaultManifest(), naisCertResources, false, clientset)
+		deployment, _ := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, newDefaultManifest(), naisCertResources, false, clientset)
 
 		envVars := deployment.Spec.Template.Spec.Containers[0].Env
 
@@ -454,7 +456,7 @@ func TestDeployment(t *testing.T) {
 				1,
 				resource1Name,
 				resource1Type,
-				Scope{"u", "u1", ZONE_FSS},
+				Scope{"u", "u1", constant.ZONE_FSS},
 				nil,
 				nil,
 				nil,
@@ -463,7 +465,7 @@ func TestDeployment(t *testing.T) {
 			},
 		}
 
-		deployment, err := createOrUpdateDeployment(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, newDefaultManifest(), resources, false, clientset)
+		deployment, err := createOrUpdateDeployment(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, newDefaultManifest(), resources, false, clientset)
 
 		assert.NoError(t, err)
 
@@ -491,7 +493,7 @@ func TestDeployment(t *testing.T) {
 			},
 		}
 
-		deploymentRequest := NaisDeploymentRequest{
+		deploymentRequest := naisrequest.Deploy{
 			Namespace:   "default",
 			Application: "myapp",
 			Version:     "1",
@@ -504,7 +506,7 @@ func TestDeployment(t *testing.T) {
 			" Change the Fasit alias or use propertyMap to create unique variable names", err.Error())
 	})
 	t.Run("Injects envoy sidecar based on settings", func(t *testing.T) {
-		deploymentRequest := NaisDeploymentRequest{
+		deploymentRequest := naisrequest.Deploy{
 			Namespace:   "default",
 			Application: "myapp",
 			Version:     "1",
@@ -542,7 +544,7 @@ func TestIngress(t *testing.T) {
 	})
 
 	t.Run("when no ingress exists, a default ingress is created", func(t *testing.T) {
-		ingress, err := createOrUpdateIngress(NaisDeploymentRequest{Namespace: namespace, Application: otherAppName}, otherTeamName, subDomain, []NaisResource{}, clientset)
+		ingress, err := createOrUpdateIngress(naisrequest.Deploy{Namespace: namespace, Application: otherAppName}, otherTeamName, subDomain, []NaisResource{}, clientset)
 
 		assert.NoError(t, err)
 		assert.Equal(t, otherAppName, ingress.ObjectMeta.Name)
@@ -556,7 +558,7 @@ func TestIngress(t *testing.T) {
 
 	t.Run("when ingress is created in non-default namespace, hostname is postfixed with namespace", func(t *testing.T) {
 		namespace := "nondefault"
-		ingress, err := createOrUpdateIngress(NaisDeploymentRequest{Namespace: namespace, Application: otherAppName}, teamName, subDomain, []NaisResource{}, clientset)
+		ingress, err := createOrUpdateIngress(naisrequest.Deploy{Namespace: namespace, Application: otherAppName}, teamName, subDomain, []NaisResource{}, clientset)
 		assert.NoError(t, err)
 		assert.Equal(t, otherAppName+"-"+namespace+"."+subDomain, ingress.Spec.Rules[0].Host)
 	})
@@ -577,7 +579,7 @@ func TestIngress(t *testing.T) {
 				},
 			},
 		}
-		ingress, err := createOrUpdateIngress(NaisDeploymentRequest{Namespace: namespace, Application: otherAppName}, teamName, subDomain, naisResources, clientset)
+		ingress, err := createOrUpdateIngress(naisrequest.Deploy{Namespace: namespace, Application: otherAppName}, teamName, subDomain, naisResources, clientset)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(ingress.Spec.Rules))
@@ -596,7 +598,7 @@ func TestIngress(t *testing.T) {
 		clientset := fake.NewSimpleClientset(ingress) //Avoid interfering with other tests in suite.
 		var naisResources []NaisResource
 
-		ingress, err := createOrUpdateIngress(NaisDeploymentRequest{Namespace: namespace, Application: "testapp", Zone: ZONE_SBS, FasitEnvironment: "testenv"}, teamName, subDomain, naisResources, clientset)
+		ingress, err := createOrUpdateIngress(naisrequest.Deploy{Namespace: namespace, Application: "testapp", Zone: constant.ZONE_SBS, FasitEnvironment: "testenv"}, teamName, subDomain, naisResources, clientset)
 		rules := ingress.Spec.Rules
 
 		assert.NoError(t, err)
@@ -642,7 +644,7 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 			1,
 			resource1Name,
 			resource1Type,
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{resource1Key: resource1Value},
 			map[string]string{},
 			map[string]string{secret1Key: secret1Value},
@@ -652,7 +654,7 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 			1,
 			resource2Name,
 			resource2Type,
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{resource2Key: resource2Value},
 			map[string]string{},
 			map[string]string{secret2Key: secret2Value},
@@ -678,7 +680,7 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 	})
 
 	t.Run("when no secret exists, a new one is created", func(t *testing.T) {
-		secret, err := createOrUpdateSecret(NaisDeploymentRequest{Namespace: namespace, Application: otherAppName}, naisResources, clientset, otherTeamName)
+		secret, err := createOrUpdateSecret(naisrequest.Deploy{Namespace: namespace, Application: otherAppName}, naisResources, clientset, otherTeamName)
 		assert.NoError(t, err)
 		assert.Equal(t, "", secret.ObjectMeta.ResourceVersion)
 		assert.Equal(t, otherAppName, secret.ObjectMeta.Name)
@@ -693,12 +695,12 @@ func TestCreateOrUpdateSecret(t *testing.T) {
 	t.Run("when a secret exists, it's updated", func(t *testing.T) {
 		updatedSecretValue := "newsecret"
 		updatedFileValue := []byte("newfile")
-		secret, err := createOrUpdateSecret(NaisDeploymentRequest{Namespace: namespace, Application: appName}, []NaisResource{
+		secret, err := createOrUpdateSecret(naisrequest.Deploy{Namespace: namespace, Application: appName}, []NaisResource{
 			{
 				1,
 				resource1Name,
 				resource1Type,
-				Scope{"u", "u1", ZONE_FSS},
+				Scope{"u", "u1", constant.ZONE_FSS},
 				nil,
 				map[string]string{},
 				map[string]string{secret1Key: updatedSecretValue},
@@ -734,7 +736,7 @@ func TestCreateOrUpdateAutoscaler(t *testing.T) {
 	})
 
 	t.Run("when no autoscaler exists, a new one is created", func(t *testing.T) {
-		autoscaler, err := createOrUpdateAutoscaler(NaisDeploymentRequest{Namespace: namespace, Application: otherAppName}, NaisManifest{Replicas: Replicas{Max: 1, Min: 2, CpuThresholdPercentage: 69}, Team: otherTeamName}, clientset)
+		autoscaler, err := createOrUpdateAutoscaler(naisrequest.Deploy{Namespace: namespace, Application: otherAppName}, NaisManifest{Replicas: Replicas{Max: 1, Min: 2, CpuThresholdPercentage: 69}, Team: otherTeamName}, clientset)
 		assert.NoError(t, err)
 		assert.Equal(t, "", autoscaler.ObjectMeta.ResourceVersion)
 		assert.Equal(t, int32(1), autoscaler.Spec.MaxReplicas)
@@ -751,7 +753,7 @@ func TestCreateOrUpdateAutoscaler(t *testing.T) {
 		cpuThreshold := 69
 		minReplicas := 6
 		maxReplicas := 9
-		autoscaler, err := createOrUpdateAutoscaler(NaisDeploymentRequest{Namespace: namespace, Application: appName}, NaisManifest{Replicas: Replicas{CpuThresholdPercentage: cpuThreshold, Min: minReplicas, Max: maxReplicas}}, clientset)
+		autoscaler, err := createOrUpdateAutoscaler(naisrequest.Deploy{Namespace: namespace, Application: appName}, NaisManifest{Replicas: Replicas{CpuThresholdPercentage: cpuThreshold, Min: minReplicas, Max: maxReplicas}}, clientset)
 		assert.NoError(t, err)
 		assert.Equal(t, resourceVersion, autoscaler.ObjectMeta.ResourceVersion)
 		assert.Equal(t, namespace, autoscaler.ObjectMeta.Namespace)
@@ -772,7 +774,7 @@ func TestDNS1123ValidResourceNames(t *testing.T) {
 			1,
 			"name",
 			"resourcrType",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			nil,
 			nil,
 			nil,
@@ -782,13 +784,13 @@ func TestDNS1123ValidResourceNames(t *testing.T) {
 	}
 
 	t.Run("Generate valid volume mount name", func(t *testing.T) {
-		volumeMount := createCertificateVolumeMount(NaisDeploymentRequest{Namespace: namespace, Application: name}, naisResource)
+		volumeMount := createCertificateVolumeMount(naisrequest.Deploy{Namespace: namespace, Application: name}, naisResource)
 		assert.Equal(t, "key-underscore-upper", volumeMount.Name)
 
 	})
 
 	t.Run("Generate valid volume name", func(t *testing.T) {
-		volume := createCertificateVolume(NaisDeploymentRequest{Namespace: namespace, Application: name}, naisResource)
+		volume := createCertificateVolume(naisrequest.Deploy{Namespace: namespace, Application: name}, naisResource)
 		assert.Equal(t, "key-underscore-upper", volume.Name)
 
 	})
@@ -796,7 +798,7 @@ func TestDNS1123ValidResourceNames(t *testing.T) {
 }
 
 func TestCreateK8sResources(t *testing.T) {
-	deploymentRequest := NaisDeploymentRequest{
+	deploymentRequest := naisrequest.Deploy{
 		Application:      appName,
 		Version:          version,
 		FasitEnvironment: namespace,
@@ -826,7 +828,7 @@ func TestCreateK8sResources(t *testing.T) {
 			1,
 			"resourceName",
 			"resourceType",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{"resourceKey": "resource1Value"},
 			nil,
 			map[string]string{"secretKey": "secretValue"},
@@ -860,7 +862,7 @@ func TestCreateK8sResources(t *testing.T) {
 			1,
 			"resourceName",
 			"resourceType",
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{"resourceKey": "resource1Value"},
 			map[string]string{},
 			map[string]string{},
@@ -907,7 +909,7 @@ func TestCheckForDuplicates(t *testing.T) {
 			},
 		}
 
-		deploymentRequest := NaisDeploymentRequest{
+		deploymentRequest := naisrequest.Deploy{
 			Application: "myapp",
 			Version:     "1",
 		}
@@ -953,9 +955,9 @@ func TestCheckForDuplicates(t *testing.T) {
 func TestCreateSBSPublicHostname(t *testing.T) {
 
 	t.Run("p", func(t *testing.T) {
-		assert.Equal(t, "tjenester.nav.no", createSBSPublicHostname(NaisDeploymentRequest{FasitEnvironment: "p"}))
-		assert.Equal(t, "tjenester-t6.nav.no", createSBSPublicHostname(NaisDeploymentRequest{FasitEnvironment: "t6"}))
-		assert.Equal(t, "tjenester-q6.nav.no", createSBSPublicHostname(NaisDeploymentRequest{FasitEnvironment: "q6"}))
+		assert.Equal(t, "tjenester.nav.no", createSBSPublicHostname(naisrequest.Deploy{FasitEnvironment: "p"}))
+		assert.Equal(t, "tjenester-t6.nav.no", createSBSPublicHostname(naisrequest.Deploy{FasitEnvironment: "t6"}))
+		assert.Equal(t, "tjenester-q6.nav.no", createSBSPublicHostname(naisrequest.Deploy{FasitEnvironment: "q6"}))
 	})
 }
 

--- a/api/resourcedeleter_test.go
+++ b/api/resourcedeleter_test.go
@@ -1,12 +1,13 @@
 package api
 
 import (
-	"testing"
+	"github.com/nais/naisd/api/constant"
+	"github.com/nais/naisd/api/naisrequest"
+	"github.com/stretchr/testify/assert"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"github.com/stretchr/testify/assert"
+	"testing"
 )
-
 
 func TestDeleteK8sResouces(t *testing.T) {
 	resourceName := "r1"
@@ -22,7 +23,7 @@ func TestDeleteK8sResouces(t *testing.T) {
 			1,
 			resourceName,
 			resourceType,
-			Scope{"u", "u1", ZONE_FSS},
+			Scope{"u", "u1", constant.ZONE_FSS},
 			map[string]string{resourceKey: resourceValue},
 			map[string]string{},
 			map[string]string{secretKey: secretValue},
@@ -31,14 +32,14 @@ func TestDeleteK8sResouces(t *testing.T) {
 		},
 	}
 
-	naisDeploymentRequest := NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}
+	naisDeploymentRequest := naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}
 	deploymentDef, _ := createDeploymentDef(naisResources, newDefaultManifest(), naisDeploymentRequest, nil, false)
 	secretDef := createSecretDef(naisResources, nil, appName, namespace, teamName)
 	secretDef.ObjectMeta.ResourceVersion = resourceVersion
 	configMapDef := createConfigMapDef(AlertsConfigMapName, AlertsConfigMapNamespace, teamName)
 	configMapDef.ObjectMeta.ResourceVersion = resourceVersion
 	clientset := fake.NewSimpleClientset(serviceDef, deploymentDef, secretDef, configMapDef)
-	createService(NaisDeploymentRequest{Namespace: namespace, Application: appName, Version: version}, teamName, clientset)
+	createService(naisrequest.Deploy{Namespace: namespace, Application: appName, Version: version}, teamName, clientset)
 
 	t.Run("Deleting non-existing app should return no error and not nil result", func(t *testing.T) {
 		res, err := deleteK8sResouces("nonexisting", appName, clientset)
@@ -110,7 +111,7 @@ func TestDeleteIngress(t *testing.T) {
 	clientset := fake.NewSimpleClientset(ingress)
 
 	t.Run("No error when ingress not present", func(t *testing.T) {
-		res, err := deleteIngress(namespace,"nonexisting", clientset)
+		res, err := deleteIngress(namespace, "nonexisting", clientset)
 		assert.NoError(t, err)
 		assert.Empty(t, res)
 		ingress, err := getExistingIngress(appName, namespace, clientset)
@@ -149,7 +150,7 @@ func TestDeleteConfigMapRules(t *testing.T) {
 		configmap, err := getExistingConfigMap(AlertsConfigMapName, AlertsConfigMapNamespace, clientset)
 		assert.NoError(t, err)
 		assert.NotNil(t, configmap)
-		alert, _ := configmap.Data[appName + namespace + ".yml" ]
+		alert, _ := configmap.Data[appName+namespace+".yml"]
 		assert.Empty(t, alert)
 	})
 }

--- a/api/sensuclient.go
+++ b/api/sensuclient.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/golang/glog"
+	"github.com/nais/naisd/api/naisrequest"
 	"net"
 	"time"
 )
@@ -21,7 +22,7 @@ type message struct {
 	Output      string   `json:"output"`
 }
 
-func GenerateDeployMessage(deploymentRequest *NaisDeploymentRequest, clusterName *string) ([]byte, error) {
+func GenerateDeployMessage(deploymentRequest *naisrequest.Deploy, clusterName *string) ([]byte, error) {
 	output := fmt.Sprintf("naisd.deployment,application=%s,clusterName=%s,namespace=%s version=\"%s\" %d", deploymentRequest.Application, *clusterName, deploymentRequest.Namespace, deploymentRequest.Version, time.Now().UnixNano())
 	m := message{"naisd.deployment", "metric", []string{"events_nano"}, output}
 
@@ -59,7 +60,7 @@ func sendMessage(message []byte) error {
 	return nil
 }
 
-func NotifySensuAboutDeploy(deploymentRequest *NaisDeploymentRequest, clusterName *string) {
+func NotifySensuAboutDeploy(deploymentRequest *naisrequest.Deploy, clusterName *string) {
 	message, err := GenerateDeployMessage(deploymentRequest, clusterName)
 	if err != nil {
 		glog.Errorln(err)

--- a/api/sensuclient_test.go
+++ b/api/sensuclient_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/nais/naisd/api/naisrequest"
 	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
@@ -8,16 +9,16 @@ import (
 
 func TestSensuClient(t *testing.T) {
 	t.Run("Check generated deploy message", func(t *testing.T) {
-		deploymentRequest := NaisDeploymentRequest{
-			Application: "TestApp",
-			Version: "42.0.0",
+		deploymentRequest := naisrequest.Deploy{
+			Application:      "TestApp",
+			Version:          "42.0.0",
 			FasitEnvironment: "environment",
-			Zone: "zone",
-			ManifestUrl: "manifesturl",
-			FasitUsername: "username",
-			FasitPassword: "password",
-			OnBehalfOf: "onbehalfof",
-			Namespace: "nais",
+			Zone:             "zone",
+			ManifestUrl:      "manifesturl",
+			FasitUsername:    "username",
+			FasitPassword:    "password",
+			OnBehalfOf:       "onbehalfof",
+			Namespace:        "nais",
 		}
 		clusterName := "nais-dev"
 

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -5,7 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nais/naisd/api"
+	"github.com/nais/naisd/api/constant"
+	"github.com/nais/naisd/api/naisrequest"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
@@ -69,7 +70,7 @@ var deployCmd = &cobra.Command{
 	Short: "Deploys your application",
 	Long:  `Deploys your application`,
 	Run: func(cmd *cobra.Command, args []string) {
-		deployRequest := api.NaisDeploymentRequest{
+		deployRequest := naisrequest.Deploy{
 			FasitUsername: os.Getenv("FASIT_USERNAME"),
 			FasitPassword: os.Getenv("FASIT_PASSWORD"),
 		}
@@ -78,7 +79,7 @@ var deployCmd = &cobra.Command{
 			deployRequest.FasitUsername = os.Getenv("NAIS_USERNAME")
 
 			if deployRequest.FasitUsername != "" {
-				fmt.Fprintf(os.Stderr, "Deprecation warning: NAIS_USERNAME is replaced by FASIT_USERNAME.\n" +
+				fmt.Fprintf(os.Stderr, "Deprecation warning: NAIS_USERNAME is replaced by FASIT_USERNAME.\n"+
 					"It will be removed in future versions.\n")
 			}
 		}
@@ -87,7 +88,7 @@ var deployCmd = &cobra.Command{
 			deployRequest.FasitPassword = os.Getenv("NAIS_PASSWORD")
 
 			if deployRequest.FasitPassword != "" {
-				fmt.Fprintf(os.Stderr, "Deprecation warning: NAIS_PASSWORD is replaced by FASIT_PASSWORD.\n" +
+				fmt.Fprintf(os.Stderr, "Deprecation warning: NAIS_PASSWORD is replaced by FASIT_PASSWORD.\n"+
 					"It will be removed in future versions.\n")
 			}
 		}
@@ -191,7 +192,7 @@ func init() {
 	deployCmd.Flags().StringP("version", "v", "", "version you want to deploy")
 	deployCmd.Flags().StringP("cluster", "c", "", "the cluster you want to deploy to")
 	deployCmd.Flags().StringP("fasit-environment", "e", "q0", "environment you want to use")
-	deployCmd.Flags().StringP("zone", "z", api.ZONE_FSS, "the zone the app will be in")
+	deployCmd.Flags().StringP("zone", "z", constant.ZONE_FSS, "the zone the app will be in")
 	deployCmd.Flags().StringP("namespace", "n", "default", "the kubernetes namespace")
 	deployCmd.Flags().StringP("fasit-username", "u", "", "the username")
 	deployCmd.Flags().StringP("fasit-password", "p", "", "the password")


### PR DESCRIPTION
- move to own package, naisrequest
- rename (because context is given from the originating package)
- move consts to own package as both api and naisrequest depend on it
- code analysis: remove redundant type declaration in fasit_test.go