### PR TITLE
Support comma-separated context roots in Fasit resources

### DIFF
--- a/api/fasit.go
+++ b/api/fasit.go
@@ -623,7 +623,7 @@ func parseLoadBalancerConfig(config []byte) ([]FasitIngress, error) {
 		pathList, _ := lbConfig.Path("properties.contextRoots").Data().(string)
 		paths := strings.Split(pathList, ",")
 		for _, path := range paths {
-			ingresses = append(ingresses, Ingress{Host: host, Path: path})
+			ingresses = append(ingresses, FasitIngress{Host: host, Path: path})
 		}
 	}
 

--- a/api/fasit.go
+++ b/api/fasit.go
@@ -96,6 +96,11 @@ type FasitResource struct {
 	Certificates map[string]interface{} `json:"files"`
 }
 
+type FasitIngress struct {
+	Host string
+	Path string
+}
+
 type ResourceRequest struct {
 	Alias        string
 	ResourceType string
@@ -111,7 +116,7 @@ type NaisResource struct {
 	propertyMap  map[string]string
 	secret       map[string]string
 	certificates map[string][]byte
-	ingresses    []Ingress
+	ingresses    []FasitIngress
 }
 
 func (nr NaisResource) Properties() map[string]string {
@@ -596,14 +601,14 @@ func resolveCertificates(files map[string]interface{}) (map[string][]byte, error
 
 }
 
-func parseLoadBalancerConfig(config []byte) ([]Ingress, error) {
+func parseLoadBalancerConfig(config []byte) ([]FasitIngress, error) {
 	jsn, err := gabs.ParseJSON(config)
 	if err != nil {
 		errorCounter.WithLabelValues("error_fasit").Inc()
 		return nil, fmt.Errorf("error parsing load balancer config: %s ", config)
 	}
 
-	ingresses := make([]Ingress, 0)
+	ingresses := make([]FasitIngress, 0)
 	lbConfigs, _ := jsn.Children()
 	if len(lbConfigs) == 0 {
 		return nil, nil

--- a/api/fasit.go
+++ b/api/fasit.go
@@ -620,8 +620,11 @@ func parseLoadBalancerConfig(config []byte) ([]FasitIngress, error) {
 			glog.Warning("no host found for loadbalancer config: %s", lbConfig)
 			continue
 		}
-		path, _ := lbConfig.Path("properties.contextRoots").Data().(string)
-		ingresses = append(ingresses, Ingress{Host: host, Path: path})
+		pathList, _ := lbConfig.Path("properties.contextRoots").Data().(string)
+		paths := strings.Split(pathList, ",")
+		for _, path := range paths {
+			ingresses = append(ingresses, Ingress{Host: host, Path: path})
+		}
 	}
 
 	if len(ingresses) == 0 {

--- a/api/fasit_test.go
+++ b/api/fasit_test.go
@@ -842,8 +842,8 @@ func TestParseLoadBalancerConfig(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(result))
-		assert.Equal(t, "ctxroot", result["subdomainwithctxroot.host.tld"])
-		assert.Equal(t, "", result["subdomain.host.tld"])
+		assert.Equal(t, Ingress{Path: "ctxroot", Host: "subdomainwithctxroot.host.tld"}, result[0])
+		assert.Equal(t, Ingress{Path: "", Host: "subdomain.host.tld"}, result[1])
 	})
 
 	t.Run("Err if no loadbalancer config is found", func(t *testing.T) {

--- a/api/fasit_test.go
+++ b/api/fasit_test.go
@@ -279,7 +279,7 @@ func TestGetLoadBalancerConfig(t *testing.T) {
 		resource, err := fasit.getLoadBalancerConfig("application", "environment")
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(resource.ingresses))
+		assert.Equal(t, 5, len(resource.ingresses))
 		assert.Equal(t, "LoadBalancerConfig", resource.resourceType)
 	})
 
@@ -841,9 +841,12 @@ func TestParseLoadBalancerConfig(t *testing.T) {
 		result, err := parseLoadBalancerConfig(b)
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(result))
+		assert.Equal(t, 5, len(result))
 		assert.Equal(t, Ingress{Path: "ctxroot", Host: "subdomainwithctxroot.host.tld"}, result[0])
 		assert.Equal(t, Ingress{Path: "", Host: "subdomain.host.tld"}, result[1])
+		assert.Equal(t, Ingress{Path: "multiple", Host: "subdomainwithmultiplecontextroots.host.tld"}, result[2])
+		assert.Equal(t, Ingress{Path: "context", Host: "subdomainwithmultiplecontextroots.host.tld"}, result[3])
+		assert.Equal(t, Ingress{Path: "roots", Host: "subdomainwithmultiplecontextroots.host.tld"}, result[4])
 	})
 
 	t.Run("Err if no loadbalancer config is found", func(t *testing.T) {

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -70,8 +70,6 @@ type NaisManifest struct {
 
 type Ingress struct {
 	Disabled bool
-	Host     string
-	Path     string
 }
 
 type Replicas struct {

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -70,6 +70,8 @@ type NaisManifest struct {
 
 type Ingress struct {
 	Disabled bool
+	Host     string
+	Path     string
 }
 
 type Replicas struct {

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -685,8 +685,8 @@ func createIngressRules(deploymentRequest naisrequest.Deploy, clusterSubdomain s
 
 	for _, naisResource := range naisResources {
 		if naisResource.resourceType == "LoadBalancerConfig" && len(naisResource.ingresses) > 0 {
-			for host, path := range naisResource.ingresses {
-				ingressRules = append(ingressRules, createIngressRule(deploymentRequest.Application, host, path))
+			for _, ingress := range naisResource.ingresses {
+				ingressRules = append(ingressRules, createIngressRule(deploymentRequest.Application, ingress.Host, ingress.Path))
 			}
 		}
 	}

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -339,10 +339,10 @@ func TestDeployment(t *testing.T) {
 		manifest := newDefaultManifest()
 		manifest.Istio.Enabled = true
 		deployment, _ := createOrUpdateDeployment(naisrequest.Deploy{
-			Namespace: namespace,
+			Namespace:   namespace,
 			Application: appName,
-			Version: version,
-			SkipFasit: true,
+			Version:     version,
+			SkipFasit:   true,
 		}, manifest, []NaisResource{}, false, clientset)
 
 		containers := deployment.Spec.Template.Spec.Containers
@@ -607,14 +607,14 @@ func TestIngress(t *testing.T) {
 		naisResources := []NaisResource{
 			{
 				resourceType: "LoadBalancerConfig",
-				ingresses: map[string]string{
-					"app.adeo.no": "context",
+				ingresses: []Ingress{
+					{Host: "app.adeo.no", Path: "context"},
 				},
 			},
 			{
 				resourceType: "LoadBalancerConfig",
-				ingresses: map[string]string{
-					"app2.adeo.no": "context2",
+				ingresses: []Ingress{
+					{Host: "app2.adeo.no", Path: "context2"},
 				},
 			},
 		}

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -607,13 +607,13 @@ func TestIngress(t *testing.T) {
 		naisResources := []NaisResource{
 			{
 				resourceType: "LoadBalancerConfig",
-				ingresses: []Ingress{
+				ingresses: []FasitIngress{
 					{Host: "app.adeo.no", Path: "context"},
 				},
 			},
 			{
 				resourceType: "LoadBalancerConfig",
-				ingresses: []Ingress{
+				ingresses: []FasitIngress{
 					{Host: "app2.adeo.no", Path: "context2"},
 				},
 			},

--- a/api/testdata/fasitLbConfigResponse.json
+++ b/api/testdata/fasitLbConfigResponse.json
@@ -57,5 +57,35 @@
       "self": "https://fasit.adeo.no/api/v2/resources/2719736",
       "revisions": "https://fasit.adeo.no/api/v2/resources/2719736/revisions"
     }
+  },
+  {
+    "type": "loadbalancerconfig",
+    "alias": "loadbalancer:presys",
+    "scope": {
+      "environmentclass": "t",
+      "zone": "fss",
+      "environment": "t0",
+      "application": "presys"
+    },
+    "properties": {
+      "contextRoots": "multiple,context,roots",
+      "url": "subdomainwithmultiplecontextroots.host.tld",
+      "poolName": "pool_tst_presys_t0_https_auto"
+    },
+    "secrets": {},
+    "files": {},
+    "dodgy": false,
+    "id": 2719736,
+    "created": "2017-06-16T08:09:13.407",
+    "updated": "2017-06-16T08:09:13.407",
+    "lifecycle": {},
+    "accesscontrol": {
+      "environmentclass": "t",
+      "adgroups": []
+    },
+    "links": {
+      "self": "https://fasit.adeo.no/api/v2/resources/2719736",
+      "revisions": "https://fasit.adeo.no/api/v2/resources/2719736/revisions"
+    }
   }
 ]


### PR DESCRIPTION
Previously, an array of context roots were keyed on the `host` field, which limits the number of context roots per host to one. This patch changes the data type so that we can, in theory, support multiple context roots per application.