### PR TITLE
Use separate web proxy settings for pods

### DIFF
--- a/api/manifest.go
+++ b/api/manifest.go
@@ -62,7 +62,6 @@ type NaisManifest struct {
 	FasitResources  FasitResources `yaml:"fasitResources"`
 	LeaderElection  bool           `yaml:"leaderElection"`
 	Redis           bool           `yaml:"redis"`
-	WebProxy        bool
 	Alerts          []PrometheusAlertRule
 	Logformat       string
 	Logtransform    string

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -430,16 +430,16 @@ func createEnvironmentVariables(spec app.Spec, deploymentRequest naisrequest.Dep
 	// Instead, JVM must be started with a specific set of command-line options. These are also
 	// provided as environment variables, for convenience.
 	if manifest.WebProxy {
-		proxyUrl := getEnvDualCase("NAIS_POD_HTTP_PROXY")
+		proxyURL := getEnvDualCase("NAIS_POD_HTTP_PROXY")
 		noProxy := getEnvDualCase("NAIS_POD_NO_PROXY")
 
 		// Set non-JVM environment variables
-		envVars = appendDualCaseEnvVar(envVars, "HTTP_PROXY", proxyUrl)
-		envVars = appendDualCaseEnvVar(envVars, "HTTPS_PROXY", proxyUrl)
+		envVars = appendDualCaseEnvVar(envVars, "HTTP_PROXY", proxyURL)
+		envVars = appendDualCaseEnvVar(envVars, "HTTPS_PROXY", proxyURL)
 		envVars = appendDualCaseEnvVar(envVars, "NO_PROXY", noProxy)
 
 		// Set environment variables specifically for JVM
-		javaOpts, err := proxyopts.JavaProxyOptions(proxyUrl, noProxy)
+		javaOpts, err := proxyopts.JavaProxyOptions(proxyURL, noProxy)
 		if err == nil {
 			if len(javaOpts) > 0 {
 				envVar := k8score.EnvVar{

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -417,42 +417,43 @@ func createEnvironmentVariables(spec app.Spec, deploymentRequest naisrequest.Dep
 		}
 	}
 
-	// If the deployment specifies webproxy=true in the nais manifest, the pods
-	// will have web proxy settings injected as environment variables. This is
-	// useful for automatic proxy configuration so that apps don't need to be aware
-	// of infrastructure quirks. The web proxy should be set up as an external service.
-	//
-	// Proxy settings on Linux is in a messy state. Some applications and libraries
-	// read the upper-case variables, while some read the lower-case versions.
-	// We handle this by setting both versions.
-	//
-	// On top of everything, the Java virtual machine does not honor these environment variables.
-	// Instead, JVM must be started with a specific set of command-line options. These are also
-	// provided as environment variables, for convenience.
-	if manifest.WebProxy {
-		proxyURL := getEnvDualCase("NAIS_POD_HTTP_PROXY")
-		noProxy := getEnvDualCase("NAIS_POD_NO_PROXY")
+	return createProxyEnvironmentVariables(envVars)
+}
 
-		// Set non-JVM environment variables
-		envVars = appendDualCaseEnvVar(envVars, "HTTP_PROXY", proxyURL)
-		envVars = appendDualCaseEnvVar(envVars, "HTTPS_PROXY", proxyURL)
-		envVars = appendDualCaseEnvVar(envVars, "NO_PROXY", noProxy)
+// All pods will have web proxy settings injected as environment variables. This is
+// useful for automatic proxy configuration so that apps don't need to be aware
+// of infrastructure quirks. The web proxy should be set up as an external service.
+//
+// Proxy settings on Linux is in a messy state. Some applications and libraries
+// read the upper-case variables, while some read the lower-case versions.
+// We handle this by setting both versions.
+//
+// On top of everything, the Java virtual machine does not honor these environment variables.
+// Instead, JVM must be started with a specific set of command-line options. These are also
+// provided as environment variables, for convenience.
+func createProxyEnvironmentVariables(envVars []k8score.EnvVar) ([]k8score.EnvVar, error) {
+	proxyURL := getEnvDualCase("NAIS_POD_HTTP_PROXY")
+	noProxy := getEnvDualCase("NAIS_POD_NO_PROXY")
 
-		// Set environment variables specifically for JVM
-		javaOpts, err := proxyopts.JavaProxyOptions(proxyURL, noProxy)
-		if err == nil {
-			if len(javaOpts) > 0 {
-				envVar := k8score.EnvVar{
-					Name:  "JAVA_PROXY_OPTIONS",
-					Value: javaOpts,
-				}
-				envVars = append(envVars, envVar)
+	// Set non-JVM environment variables
+	envVars = appendDualCaseEnvVar(envVars, "HTTP_PROXY", proxyURL)
+	envVars = appendDualCaseEnvVar(envVars, "HTTPS_PROXY", proxyURL)
+	envVars = appendDualCaseEnvVar(envVars, "NO_PROXY", noProxy)
+
+	// Set environment variables specifically for JVM
+	javaOpts, err := proxyopts.JavaProxyOptions(proxyURL, noProxy)
+	if err == nil {
+		if len(javaOpts) > 0 {
+			envVar := k8score.EnvVar{
+				Name:  "JAVA_PROXY_OPTIONS",
+				Value: javaOpts,
 			}
-		} else {
-			// A failure state here means that there is something wrong with the syntax
-			// of our proxy config. This situation should be made clearly visible.
-			return nil, fmt.Errorf("while converting webproxy settings to Java format: %s", err)
+			envVars = append(envVars, envVar)
 		}
+	} else {
+		// A failure state here means that there is something wrong with the syntax
+		// of our proxy config. This situation should be made clearly visible.
+		return nil, fmt.Errorf("while converting webproxy settings to Java format: %s", err)
 	}
 
 	return envVars, nil

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -436,9 +436,13 @@ func createProxyEnvironmentVariables(envVars []k8score.EnvVar) ([]k8score.EnvVar
 	noProxy := getEnvDualCase("NAIS_POD_NO_PROXY")
 
 	// Set non-JVM environment variables
-	envVars = appendDualCaseEnvVar(envVars, "HTTP_PROXY", proxyURL)
-	envVars = appendDualCaseEnvVar(envVars, "HTTPS_PROXY", proxyURL)
-	envVars = appendDualCaseEnvVar(envVars, "NO_PROXY", noProxy)
+	if len(proxyURL) > 0 {
+		envVars = appendDualCaseEnvVar(envVars, "HTTP_PROXY", proxyURL)
+		envVars = appendDualCaseEnvVar(envVars, "HTTPS_PROXY", proxyURL)
+	}
+	if len(noProxy) > 0 {
+		envVars = appendDualCaseEnvVar(envVars, "NO_PROXY", noProxy)
+	}
 
 	// Set environment variables specifically for JVM
 	javaOpts, err := proxyopts.JavaProxyOptions(proxyURL, noProxy)

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"github.com/nais/naisd/api/app"
+	"github.com/nais/naisd/proxyopts"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"os"
 	"strconv"
@@ -417,27 +418,58 @@ func createEnvironmentVariables(spec app.Spec, deploymentRequest naisrequest.Dep
 	}
 
 	// If the deployment specifies webproxy=true in the nais manifest, the pods
-	// will inherit naisd's proxy settings.  This is useful for automatic proxy
-	// configuration so that apps don't need to be aware of infrastructure quirks.
+	// will have web proxy settings injected as environment variables. This is
+	// useful for automatic proxy configuration so that apps don't need to be aware
+	// of infrastructure quirks. The web proxy should be set up as an external service.
 	//
-	// Additionally, proxy settings on Linux is in a messy state. Some
-	// applications and libraries read the upper-case variables, while some read
-	// the lower-case versions. We handle this by trying to read both versions
-	// from the naisd environment, and propagating both versions to the pod.
+	// Proxy settings on Linux is in a messy state. Some applications and libraries
+	// read the upper-case variables, while some read the lower-case versions.
+	// We handle this by setting both versions.
+	//
+	// On top of everything, the Java virtual machine does not honor these environment variables.
+	// Instead, JVM must be started with a specific set of command-line options. These are also
+	// provided as environment variables, for convenience.
 	if manifest.WebProxy {
-		for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
-			value := getEnvDualCase(key)
-			for _, mkey := range []string{strings.ToUpper(key), strings.ToLower(key)} {
+		proxyUrl := getEnvDualCase("NAIS_POD_HTTP_PROXY")
+		noProxy := getEnvDualCase("NAIS_POD_NO_PROXY")
+
+		// Set non-JVM environment variables
+		envVars = appendDualCaseEnvVar(envVars, "HTTP_PROXY", proxyUrl)
+		envVars = appendDualCaseEnvVar(envVars, "HTTPS_PROXY", proxyUrl)
+		envVars = appendDualCaseEnvVar(envVars, "NO_PROXY", noProxy)
+
+		// Set environment variables specifically for JVM
+		javaOpts, err := proxyopts.JavaProxyOptions(proxyUrl, noProxy)
+		if err == nil {
+			if len(javaOpts) > 0 {
 				envVar := k8score.EnvVar{
-					Name:  mkey,
-					Value: value,
+					Name:  "JAVA_PROXY_OPTIONS",
+					Value: javaOpts,
 				}
 				envVars = append(envVars, envVar)
 			}
+		} else {
+			// A failure state here means that there is something wrong with the syntax
+			// of our proxy config. This situation should be made clearly visible.
+			return nil, fmt.Errorf("while converting webproxy settings to Java format: %s", err)
 		}
 	}
 
 	return envVars, nil
+}
+
+// appendDualCaseEnvVar adds the specified environment variable twice to a slice.
+// One with a lowercase key, the other with an uppercase key.
+func appendDualCaseEnvVar(envVars []k8score.EnvVar, key, value string) []k8score.EnvVar {
+	for _, mkey := range []string{strings.ToUpper(key), strings.ToLower(key)} {
+		envVar := k8score.EnvVar{
+			Name:  mkey,
+			Value: value,
+		}
+		envVars = append(envVars, envVar)
+	}
+
+	return envVars
 }
 
 func getEnvDualCase(name string) string {

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -1110,7 +1110,7 @@ func TestCheckForDuplicates(t *testing.T) {
 func TestInjectProxySettings(t *testing.T) {
 	spec := app.Spec{Application: appName, Environment: environment, Team: teamName, ApplicationNamespaced: true}
 
-	t.Run("proxy settings not be injected in the pod unless requested through manifest", func(t *testing.T) {
+	t.Run("proxy settings should not be injected in the pod unless requested through manifest", func(t *testing.T) {
 		deploymentRequest := naisrequest.Deploy{
 			Application:           "myapp",
 			Version:               "1",
@@ -1121,16 +1121,16 @@ func TestInjectProxySettings(t *testing.T) {
 			WebProxy: false,
 		}
 
-		os.Setenv("HTTP_PROXY", "foo")
-		os.Setenv("HTTPS_PROXY", "bar")
-		os.Setenv("NO_PROXY", "baz")
+		os.Setenv("NAIS_POD_HTTP_PROXY", "http://foo.bar:1234")
+		os.Setenv("NAIS_POD_NO_PROXY", "baz")
 
 		env, err := createEnvironmentVariables(spec, deploymentRequest, manifest, []NaisResource{})
 
 		assert.Nil(t, err)
-		assert.NotContains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "foo"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "bar"})
+		assert.NotContains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "http://foo.bar:1234"})
+		assert.NotContains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "http://foo.bar:1234"})
 		assert.NotContains(t, env, k8score.EnvVar{Name: "NO_PROXY", Value: "baz"})
+		assert.NotContains(t, env, k8score.EnvVar{Name: "JAVA_PROXY_OPTIONS", Value: "-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=baz"})
 	})
 
 	t.Run("proxy settings should be injected in the pod if requested through manifest", func(t *testing.T) {
@@ -1144,19 +1144,19 @@ func TestInjectProxySettings(t *testing.T) {
 			WebProxy: true,
 		}
 
-		os.Setenv("HTTP_PROXY", "foo")
-		os.Setenv("https_proxy", "bar")
-		os.Setenv("NO_PROXY", "baz")
+		os.Setenv("NAIS_POD_HTTP_PROXY", "http://foo.bar:1234")
+		os.Setenv("NAIS_POD_NO_PROXY", "baz")
 
 		env, err := createEnvironmentVariables(spec, deploymentRequest, manifest, []NaisResource{})
 
 		assert.Nil(t, err)
-		assert.Contains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "foo"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "bar"})
+		assert.Contains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "http://foo.bar:1234"})
+		assert.Contains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "http://foo.bar:1234"})
 		assert.Contains(t, env, k8score.EnvVar{Name: "NO_PROXY", Value: "baz"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "http_proxy", Value: "foo"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "https_proxy", Value: "bar"})
+		assert.Contains(t, env, k8score.EnvVar{Name: "http_proxy", Value: "http://foo.bar:1234"})
+		assert.Contains(t, env, k8score.EnvVar{Name: "https_proxy", Value: "http://foo.bar:1234"})
 		assert.Contains(t, env, k8score.EnvVar{Name: "no_proxy", Value: "baz"})
+		assert.Contains(t, env, k8score.EnvVar{Name: "JAVA_PROXY_OPTIONS", Value: "-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=baz"})
 	})
 }
 

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -1110,29 +1110,6 @@ func TestCheckForDuplicates(t *testing.T) {
 func TestInjectProxySettings(t *testing.T) {
 	spec := app.Spec{Application: appName, Environment: environment, Team: teamName, ApplicationNamespaced: true}
 
-	t.Run("proxy settings should not be injected in the pod unless requested through manifest", func(t *testing.T) {
-		deploymentRequest := naisrequest.Deploy{
-			Application:           "myapp",
-			Version:               "1",
-			ApplicationNamespaced: true,
-		}
-
-		manifest := NaisManifest{
-			WebProxy: false,
-		}
-
-		os.Setenv("NAIS_POD_HTTP_PROXY", "http://foo.bar:1234")
-		os.Setenv("NAIS_POD_NO_PROXY", "baz")
-
-		env, err := createEnvironmentVariables(spec, deploymentRequest, manifest, []NaisResource{})
-
-		assert.Nil(t, err)
-		assert.NotContains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "http://foo.bar:1234"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "http://foo.bar:1234"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "NO_PROXY", Value: "baz"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "JAVA_PROXY_OPTIONS", Value: "-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=baz"})
-	})
-
 	t.Run("proxy settings should be injected in the pod if requested through manifest", func(t *testing.T) {
 		deploymentRequest := naisrequest.Deploy{
 			Application:           "myapp",
@@ -1140,9 +1117,7 @@ func TestInjectProxySettings(t *testing.T) {
 			ApplicationNamespaced: true,
 		}
 
-		manifest := NaisManifest{
-			WebProxy: true,
-		}
+		manifest := NaisManifest{}
 
 		os.Setenv("NAIS_POD_HTTP_PROXY", "http://foo.bar:1234")
 		os.Setenv("NAIS_POD_NO_PROXY", "baz")

--- a/helm/naisd/templates/deployment.yaml
+++ b/helm/naisd/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
             value: "{{ .Values.vaultAuthPath }}"
           - name: NAISD_VAULT_ENABLED
             value: "{{ .Values.vaultEnabled }}"
+          - name: NAIS_POD_HTTP_PROXY
+            value: "{{ .Values.podHttpProxy }}"
+          - name: NAIS_POD_NO_PROXY
+            value: "{{ .Values.podNoProxy }}"
 {{ if .skipProxy }}
 {{ else }}
           - name: https_proxy

--- a/nais_example.yaml
+++ b/nais_example.yaml
@@ -62,5 +62,4 @@ alerts:
     action: Investigate why nais-testapp can't spawn pods. kubectl describe deployment nais-testapp, kubectl describe pod nais-testapp-*.
 logformat: accesslog # Optional. The format of the logs from the container if the logs should be handled differently than plain text or json
 logtransform: dns_loglevel # Optional. The transformation of the logs, if they should be handled differently than plain text or json
-webproxy: false # Optional. Expose web proxy configuration to the application using the HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.
 secrets: false # Optional. If set to true fetch secrets from Secret Service and inject into the pods. todo link to doc.

--- a/proxyopts/proxyopts.go
+++ b/proxyopts/proxyopts.go
@@ -1,0 +1,95 @@
+package proxyopts
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type javaOption struct {
+	Key   string
+	Value string
+}
+
+type javaOptions []javaOption
+
+func (o javaOption) Format() string {
+	return fmt.Sprintf("-D%s=%s", o.Key, o.Value)
+}
+
+func newJavaOption(key string, value string) javaOption {
+	return javaOption{
+		Key:   key,
+		Value: value,
+	}
+}
+
+func (o javaOptions) Format() string {
+	s := make([]string, len(o))
+	for i, opt := range o {
+		s[i] = opt.Format()
+	}
+	return strings.Join(s, " ")
+}
+
+func httpOpts(flags javaOptions, proxyUrl string) (javaOptions, error) {
+	if len(proxyUrl) == 0 {
+		return flags, nil
+	}
+
+	u, err := url.Parse(proxyUrl)
+	if err != nil {
+		return flags, err
+	}
+
+	if len(u.Hostname()) == 0 || len(u.Port()) == 0 {
+		return flags, fmt.Errorf("if specifying a proxy URL, both hostname and port is required")
+	}
+
+	flags = append(flags, newJavaOption("http.proxyHost", u.Hostname()))
+	flags = append(flags, newJavaOption("https.proxyHost", u.Hostname()))
+	flags = append(flags, newJavaOption("http.proxyPort", u.Port()))
+	flags = append(flags, newJavaOption("https.proxyPort", u.Port()))
+
+	return flags, nil
+}
+
+// mangleWildcard takes a list of hostnames and prepends '*' if the hostname
+// starts with '.', then returns a new slice with the modified hostnames.
+func mangleWildcard(hosts []string) []string {
+	mangled := make([]string, len(hosts))
+	for i, host := range hosts {
+		if len(host) > 0 && host[0] == '.' {
+			host = "*" + host
+		}
+		mangled[i] = host
+	}
+	return mangled
+}
+
+func noProxyOpts(flags javaOptions, noProxy string) (javaOptions, error) {
+	if len(noProxy) == 0 {
+		return flags, nil
+	}
+
+	hosts := mangleWildcard(strings.Split(noProxy, ","))
+	flags = append(flags, newJavaOption("http.nonProxyHosts", strings.Join(hosts, "|")))
+
+	return flags, nil
+}
+
+func JavaProxyOptions(proxyUrl, noProxy string) (s string, err error) {
+	flags := make(javaOptions, 0)
+
+	flags, err = httpOpts(flags, proxyUrl)
+	if err != nil {
+		err = fmt.Errorf("error in parsing proxy URL: %s", err)
+		return
+	}
+
+	flags, _ = noProxyOpts(flags, noProxy)
+
+	s = flags.Format()
+
+	return
+}

--- a/proxyopts/proxyopts.go
+++ b/proxyopts/proxyopts.go
@@ -32,12 +32,12 @@ func (o javaOptions) Format() string {
 	return strings.Join(s, " ")
 }
 
-func httpOpts(flags javaOptions, proxyUrl string) (javaOptions, error) {
-	if len(proxyUrl) == 0 {
+func httpOpts(flags javaOptions, proxyURL string) (javaOptions, error) {
+	if len(proxyURL) == 0 {
 		return flags, nil
 	}
 
-	u, err := url.Parse(proxyUrl)
+	u, err := url.Parse(proxyURL)
 	if err != nil {
 		return flags, err
 	}
@@ -78,10 +78,12 @@ func noProxyOpts(flags javaOptions, noProxy string) (javaOptions, error) {
 	return flags, nil
 }
 
-func JavaProxyOptions(proxyUrl, noProxy string) (s string, err error) {
+// JavaProxyOptions converts *NIX style http proxy environment variables
+// $HTTP_PROXY and $NO_PROXY to JVM startup flag equivalents.
+func JavaProxyOptions(proxyURL, noProxy string) (s string, err error) {
 	flags := make(javaOptions, 0)
 
-	flags, err = httpOpts(flags, proxyUrl)
+	flags, err = httpOpts(flags, proxyURL)
 	if err != nil {
 		err = fmt.Errorf("error in parsing proxy URL: %s", err)
 		return

--- a/proxyopts/proxyopts_test.go
+++ b/proxyopts/proxyopts_test.go
@@ -1,0 +1,64 @@
+package proxyopts
+
+import (
+	"testing"
+)
+
+var testCases = []struct {
+	proxyUrl string
+	noProxy  string
+	Output   string
+	Error    bool
+}{
+	{
+		proxyUrl: "http://foo.bar:1234",
+		Output:   `-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234`,
+	},
+	{
+		Output: ``,
+	},
+	{
+		proxyUrl: "http://foo.bar:1234",
+		Output:   `-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234`,
+	},
+	{
+		noProxy: "internalhost",
+		Output:  `-Dhttp.nonProxyHosts=internalhost`,
+	},
+	{
+		noProxy: "host1,host2,.wildcard.local,.local,foo",
+		Output:  `-Dhttp.nonProxyHosts=host1|host2|*.wildcard.local|*.local|foo`,
+	},
+	{
+		proxyUrl: "http://foo.bar:1234",
+		noProxy:  "host1,host2,.wildcard.local,.local,foo",
+		Output:   `-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=host1|host2|*.wildcard.local|*.local|foo`,
+	},
+	{
+		proxyUrl: "foo.bar:1234",
+		Error:    true,
+	},
+	{
+		proxyUrl: "http://proxy",
+		Error:    true,
+	},
+}
+
+func TestSuccess(t *testing.T) {
+	for i, test := range testCases {
+		output, err := JavaProxyOptions(test.proxyUrl, test.noProxy)
+
+		if test.Error {
+			if err == nil {
+				t.Fatalf("Test #%d: expected error, got success instead", i)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("Test #%d: expected success, got error: %s", i, err)
+			}
+			if output != test.Output {
+				t.Fatalf("Test #%d: expected output \"%s\", got \"%s\"", i, test.Output, output)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This patch changes the source of pods' web proxy configuration from `HTTP_PROXY` and `NO_PROXY` to `NAIS_POD_HTTP_PROXY` and `NAIS_POD_NO_PROXY`, respectively.

Additionally, a `JAVA_PROXY_OPTIONS` environment variable is added, to ease the pain of having to set up this separately in Java applications. We have several different implementations of this at NAV, and this approach will provide users with platform-provided values so that they can focus on delivering applications instead of tinkering with infrastructure details.