### PR TITLE
Inject webproxy variables only when requested

### DIFF
--- a/api/manifest.go
+++ b/api/manifest.go
@@ -66,6 +66,7 @@ type NaisManifest struct {
 	Logformat       string
 	Logtransform    string
 	Secrets         bool `yaml:"secrets"`
+	Webproxy        bool `yaml:"webproxy"`
 }
 
 type Ingress struct {

--- a/api/resourcecreator.go
+++ b/api/resourcecreator.go
@@ -417,7 +417,11 @@ func createEnvironmentVariables(spec app.Spec, deploymentRequest naisrequest.Dep
 		}
 	}
 
-	return createProxyEnvironmentVariables(envVars)
+	if manifest.Webproxy {
+		return createProxyEnvironmentVariables(envVars)
+	}
+
+	return envVars, nil
 }
 
 // All pods will have web proxy settings injected as environment variables. This is

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/nais/naisd/api/app"
 	"github.com/nais/naisd/pkg/test"
-	"os"
 	"strings"
 	"testing"
 
@@ -1128,9 +1127,6 @@ func TestInjectProxySettings(t *testing.T) {
 					Webproxy: true,
 				}
 
-				os.Setenv("NAIS_POD_HTTP_PROXY", "http://foo.bar:1234")
-				os.Setenv("NAIS_POD_NO_PROXY", "baz")
-
 				env, err := createEnvironmentVariables(spec, deploymentRequest, manifest, []NaisResource{})
 
 				assert.Nil(t, err)
@@ -1142,31 +1138,28 @@ func TestInjectProxySettings(t *testing.T) {
 				assert.Contains(t, env, k8score.EnvVar{Name: "no_proxy", Value: "baz"})
 				assert.Contains(t, env, k8score.EnvVar{Name: "JAVA_PROXY_OPTIONS", Value: "-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=baz"})
 			})
+
+			t.Run("proxy settings should not be injected in the pod unless requested through manifest", func(t *testing.T) {
+				deploymentRequest := naisrequest.Deploy{
+					Application:           "myapp",
+					Version:               "1",
+					ApplicationNamespaced: true,
+				}
+
+				manifest := NaisManifest{}
+
+				env, err := createEnvironmentVariables(spec, deploymentRequest, manifest, []NaisResource{})
+
+				assert.Nil(t, err)
+				assert.NotContains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "http://foo.bar:1234"})
+				assert.NotContains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "http://foo.bar:1234"})
+				assert.NotContains(t, env, k8score.EnvVar{Name: "NO_PROXY", Value: "baz"})
+				assert.NotContains(t, env, k8score.EnvVar{Name: "http_proxy", Value: "http://foo.bar:1234"})
+				assert.NotContains(t, env, k8score.EnvVar{Name: "https_proxy", Value: "http://foo.bar:1234"})
+				assert.NotContains(t, env, k8score.EnvVar{Name: "no_proxy", Value: "baz"})
+				assert.NotContains(t, env, k8score.EnvVar{Name: "JAVA_PROXY_OPTIONS", Value: "-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=baz"})
+			})
 		})
-
-	t.Run("proxy settings should not be injected in the pod unless requested through manifest", func(t *testing.T) {
-		deploymentRequest := naisrequest.Deploy{
-			Application:           "myapp",
-			Version:               "1",
-			ApplicationNamespaced: true,
-		}
-
-		manifest := NaisManifest{}
-
-		os.Setenv("NAIS_POD_HTTP_PROXY", "http://foo.bar:1234")
-		os.Setenv("NAIS_POD_NO_PROXY", "baz")
-
-		env, err := createEnvironmentVariables(spec, deploymentRequest, manifest, []NaisResource{})
-
-		assert.Nil(t, err)
-		assert.NotContains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "http://foo.bar:1234"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "http://foo.bar:1234"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "NO_PROXY", Value: "baz"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "http_proxy", Value: "http://foo.bar:1234"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "https_proxy", Value: "http://foo.bar:1234"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "no_proxy", Value: "baz"})
-		assert.NotContains(t, env, k8score.EnvVar{Name: "JAVA_PROXY_OPTIONS", Value: "-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=baz"})
-	})
 }
 
 func TestCreateSBSPublicHostname(t *testing.T) {

--- a/api/resourcecreator_test.go
+++ b/api/resourcecreator_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"github.com/nais/naisd/api/app"
+	"github.com/nais/naisd/pkg/test"
 	"os"
 	"strings"
 	"testing"
@@ -628,7 +629,7 @@ func TestIngress(t *testing.T) {
 	})
 
 	t.Run("Nais ingress resources are added", func(t *testing.T) {
-		clientset := fake.NewSimpleClientset(ingress) //Avoid interfering with other tests in suite.
+		clientset := fake.NewSimpleClientset(ingress) // Avoid interfering with other tests in suite.
 		naisResources := []NaisResource{
 			{
 				resourceType: "LoadBalancerConfig",
@@ -659,7 +660,7 @@ func TestIngress(t *testing.T) {
 	})
 
 	t.Run("sbs ingress are added", func(t *testing.T) {
-		clientset := fake.NewSimpleClientset(ingress) //Avoid interfering with other tests in suite.
+		clientset := fake.NewSimpleClientset(ingress) // Avoid interfering with other tests in suite.
 		var naisResources []NaisResource
 
 		ingress, err := createOrUpdateIngress(spec, naisrequest.Deploy{Environment: environment, Application: spec.Application, Zone: constant.ZONE_SBS, FasitEnvironment: spec.Environment, ApplicationNamespaced: true}, subDomain, naisResources, clientset)
@@ -1109,32 +1110,39 @@ func TestCheckForDuplicates(t *testing.T) {
 
 func TestInjectProxySettings(t *testing.T) {
 	spec := app.Spec{Application: appName, Environment: environment, Team: teamName, ApplicationNamespaced: true}
+	vars := map[string]string{
+		"NAIS_POD_HTTP_PROXY": "http://foo.bar:1234",
+		"NAIS_POD_NO_PROXY":   "baz",
+	}
 
-	t.Run("proxy settings should be injected in the pod if requested through manifest", func(t *testing.T) {
-		deploymentRequest := naisrequest.Deploy{
-			Application:           "myapp",
-			Version:               "1",
-			ApplicationNamespaced: true,
-		}
+	test.EnvWrapper(vars,
+		func(t *testing.T) {
+			t.Run("proxy settings should be injected in the pod if requested through manifest", func(t *testing.T) {
+				deploymentRequest := naisrequest.Deploy{
+					Application:           "myapp",
+					Version:               "1",
+					ApplicationNamespaced: true,
+				}
 
-		manifest := NaisManifest{
-			Webproxy: true,
-		}
+				manifest := NaisManifest{
+					Webproxy: true,
+				}
 
-		os.Setenv("NAIS_POD_HTTP_PROXY", "http://foo.bar:1234")
-		os.Setenv("NAIS_POD_NO_PROXY", "baz")
+				os.Setenv("NAIS_POD_HTTP_PROXY", "http://foo.bar:1234")
+				os.Setenv("NAIS_POD_NO_PROXY", "baz")
 
-		env, err := createEnvironmentVariables(spec, deploymentRequest, manifest, []NaisResource{})
+				env, err := createEnvironmentVariables(spec, deploymentRequest, manifest, []NaisResource{})
 
-		assert.Nil(t, err)
-		assert.Contains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "http://foo.bar:1234"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "http://foo.bar:1234"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "NO_PROXY", Value: "baz"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "http_proxy", Value: "http://foo.bar:1234"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "https_proxy", Value: "http://foo.bar:1234"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "no_proxy", Value: "baz"})
-		assert.Contains(t, env, k8score.EnvVar{Name: "JAVA_PROXY_OPTIONS", Value: "-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=baz"})
-	})
+				assert.Nil(t, err)
+				assert.Contains(t, env, k8score.EnvVar{Name: "HTTP_PROXY", Value: "http://foo.bar:1234"})
+				assert.Contains(t, env, k8score.EnvVar{Name: "HTTPS_PROXY", Value: "http://foo.bar:1234"})
+				assert.Contains(t, env, k8score.EnvVar{Name: "NO_PROXY", Value: "baz"})
+				assert.Contains(t, env, k8score.EnvVar{Name: "http_proxy", Value: "http://foo.bar:1234"})
+				assert.Contains(t, env, k8score.EnvVar{Name: "https_proxy", Value: "http://foo.bar:1234"})
+				assert.Contains(t, env, k8score.EnvVar{Name: "no_proxy", Value: "baz"})
+				assert.Contains(t, env, k8score.EnvVar{Name: "JAVA_PROXY_OPTIONS", Value: "-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=baz"})
+			})
+		})
 
 	t.Run("proxy settings should not be injected in the pod unless requested through manifest", func(t *testing.T) {
 		deploymentRequest := naisrequest.Deploy{


### PR DESCRIPTION
This fixes a service discovery regression introduced in 4d7a9f68c7313e1c28d188b8d63d62f3501f71ad, where unconditional web proxy settings injection caused trouble for applications doing service discovery.

Apparently, the `NO_PROXY` variable applies to hosts _before_ the DNS lookup is returned. Thus, filtering on cluster level (e.g., `.local`, `.adeo.no`, etc.) will not work if applications only specify the host name component.

This commit reintroduces the `webproxy` manifest property so that application maintainers can decide for themselves whether or not they want the variables injected.