### PR TITLE
Expose the fasit resource type SoapService

### DIFF
--- a/api/fasit.go
+++ b/api/fasit.go
@@ -775,12 +775,6 @@ func buildResourcePayload(resource ExposedResource, existingResource NaisResourc
 		}
 
 	} else if strings.EqualFold("WebserviceEndpoint", resource.ResourceType) || strings.EqualFold("SoapService", resource.ResourceType) {
-		var resourceType string
-		if strings.EqualFold("SoapService", resource.ResourceType) {
-			resourceType = "SoapService"
-		} else {
-			resourceType = "WebserviceEndpoint"
-		}
 		Url, _ := url.Parse("http://maven.adeo.no/nexus/service/local/artifact/maven/redirect")
 		wsdlArtifactQuery := url.Values{}
 		wsdlArtifactQuery.Add("r", "m2internal")
@@ -791,7 +785,7 @@ func buildResourcePayload(resource ExposedResource, existingResource NaisResourc
 		Url.RawQuery = wsdlArtifactQuery.Encode()
 
 		return WebserviceResourcePayload{
-			Type:  resourceType,
+			Type:  resource.ResourceType,
 			Alias: resource.Alias,
 			Properties: WebserviceProperties{
 				EndpointUrl:   "https://" + hostname + resource.Path,

--- a/api/fasit.go
+++ b/api/fasit.go
@@ -774,7 +774,7 @@ func buildResourcePayload(resource ExposedResource, existingResource NaisResourc
 			Scope: generateScope(resource, existingResource, fasitEnvironmentClass, fasitEnvironment, zone),
 		}
 
-	} else if (strings.EqualFold("WebserviceEndpoint", resource.ResourceType) || strings.EqualFold("SoapService", resource.ResourceType)) {
+	} else if strings.EqualFold("WebserviceEndpoint", resource.ResourceType) || strings.EqualFold("SoapService", resource.ResourceType) {
 		var resourceType string
 		if strings.EqualFold("SoapService", resource.ResourceType) {
 			resourceType = "SoapService"

--- a/api/fasit.go
+++ b/api/fasit.go
@@ -782,13 +782,13 @@ func buildResourcePayload(resource ExposedResource, existingResource NaisResourc
 			resourceType = "WebserviceEndpoint"
 		}
 		Url, _ := url.Parse("http://maven.adeo.no/nexus/service/local/artifact/maven/redirect")
-		q := url.Values{}
-		q.Add("r", "m2internal")
-		q.Add("g", resource.WsdlGroupId)
-		q.Add("a", resource.WsdlArtifactId)
-		q.Add("v", resource.WsdlVersion)
-		q.Add("e", "zip")
-		Url.RawQuery = q.Encode()
+		wsdlArtifactQuery := url.Values{}
+		wsdlArtifactQuery.Add("r", "m2internal")
+		wsdlArtifactQuery.Add("g", resource.WsdlGroupId)
+		wsdlArtifactQuery.Add("a", resource.WsdlArtifactId)
+		wsdlArtifactQuery.Add("v", resource.WsdlVersion)
+		wsdlArtifactQuery.Add("e", "zip")
+		Url.RawQuery = wsdlArtifactQuery.Encode()
 
 		return WebserviceResourcePayload{
 			Type:  resourceType,

--- a/api/fasit.go
+++ b/api/fasit.go
@@ -762,7 +762,7 @@ func buildApplicationInstancePayload(deploymentRequest naisrequest.Deploy, fasit
 
 func buildResourcePayload(resource ExposedResource, existingResource NaisResource, fasitEnvironmentClass, fasitEnvironment, zone, hostname string) ResourcePayload {
 	// Reference of valid resources in Fasit
-	// ['DataSource', 'MSSQLDataSource', 'DB2DataSource', 'LDAP', 'BaseUrl', 'Credential', 'Certificate', 'OpenAm', 'Cics', 'RoleMapping', 'QueueManager', 'WebserviceEndpoint', 'RestService', 'WebserviceGateway', 'EJB', 'Datapower', 'EmailAddress', 'SMTPServer', 'Queue', 'Topic', 'DeploymentManager', 'ApplicationProperties', 'MemoryParameters', 'LoadBalancer', 'LoadBalancerConfig', 'FileLibrary', 'Channel
+	// ['DataSource', 'MSSQLDataSource', 'DB2DataSource', 'LDAP', 'BaseUrl', 'Credential', 'Certificate', 'OpenAm', 'Cics', 'RoleMapping', 'QueueManager', 'WebserviceEndpoint', 'SoapService', 'RestService', 'WebserviceGateway', 'EJB', 'Datapower', 'EmailAddress', 'SMTPServer', 'Queue', 'Topic', 'DeploymentManager', 'ApplicationProperties', 'MemoryParameters', 'LoadBalancer', 'LoadBalancerConfig', 'FileLibrary', 'Channel
 	if strings.EqualFold("restservice", resource.ResourceType) {
 		return RestResourcePayload{
 			Type:  "RestService",
@@ -774,7 +774,13 @@ func buildResourcePayload(resource ExposedResource, existingResource NaisResourc
 			Scope: generateScope(resource, existingResource, fasitEnvironmentClass, fasitEnvironment, zone),
 		}
 
-	} else if strings.EqualFold("WebserviceEndpoint", resource.ResourceType) {
+	} else if (strings.EqualFold("WebserviceEndpoint", resource.ResourceType) || strings.EqualFold("SoapService", resource.ResourceType)) {
+		var resourceType string
+		if strings.EqualFold("SoapService", resource.ResourceType) {
+			resourceType = "SoapService"
+		} else {
+			resourceType = "WebserviceEndpoint"
+		}
 		Url, _ := url.Parse("http://maven.adeo.no/nexus/service/local/artifact/maven/redirect")
 		q := url.Values{}
 		q.Add("r", "m2internal")
@@ -785,7 +791,7 @@ func buildResourcePayload(resource ExposedResource, existingResource NaisResourc
 		Url.RawQuery = q.Encode()
 
 		return WebserviceResourcePayload{
-			Type:  "WebserviceEndpoint",
+			Type:  resourceType,
 			Alias: resource.Alias,
 			Properties: WebserviceProperties{
 				EndpointUrl:   "https://" + hostname + resource.Path,

--- a/api/fasit_test.go
+++ b/api/fasit_test.go
@@ -511,6 +511,16 @@ func TestBuildingFasitPayloads(t *testing.T) {
 		SecurityToken:  securityToken,
 		Description:    description,
 	}
+	soapServiceResource := ExposedResource{
+		Alias:          alias,
+		ResourceType:   "SoapService",
+		Path:           path,
+		WsdlGroupId:    wsdlGroupId,
+		WsdlArtifactId: wsdlArtifactId,
+		WsdlVersion:    version,
+		SecurityToken:  securityToken,
+		Description:    description,
+	}
 	exposedResources := []Resource{{1}, {2}, {3}}
 	usedResources := []Resource{{4}, {5}, {6}}
 
@@ -568,6 +578,16 @@ func TestBuildingFasitPayloads(t *testing.T) {
 		assert.Equal(t, environment, payload.Scope.Environment)
 		assert.Equal(t, zone, payload.Scope.Zone)
 	})
+	t.Run("Building SoapService ResourcePayload", func(t *testing.T) {
+		payloadReturn := buildResourcePayload(soapServiceResource, NaisResource{}, class, environment, zone, hostname)
+		payload, _ := payloadReturn.(WebserviceResourcePayload)
+		assert.Equal(t, "SoapService", payload.Type)
+		assert.Equal(t, alias, payload.Alias)
+		assert.Equal(t, wsdlPath, payload.Properties.WsdlUrl)
+		assert.Equal(t, description, payload.Properties.Description)
+		assert.Equal(t, environment, payload.Scope.Environment)
+		assert.Equal(t, zone, payload.Scope.Zone)
+	})
 	t.Run("Marshalling Webservice payloads yields expected result", func(t *testing.T) {
 
 		payload, err := json.Marshal(buildResourcePayload(webserviceResource, NaisResource{}, class, environment, zone, hostname))
@@ -575,6 +595,14 @@ func TestBuildingFasitPayloads(t *testing.T) {
 		assert.NoError(t, err)
 		n := len(payload)
 		assert.Equal(t, "{\"alias\":\"resourceAlias\",\"scope\":{\"environmentclass\":\"t\",\"environment\":\"t1000\",\"zone\":\"fss\"},\"type\":\"WebserviceEndpoint\",\"properties\":{\"endpointUrl\":\"https://hostname/myPath\",\"wsdlUrl\":\"http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?a=myArtifactId&e=zip&g=myGroup&r=m2internal&v=2.1\",\"securityToken\":\"LDAP\",\"description\":\"myDescription\"}}", string(payload[:n]))
+	})
+	t.Run("Marshalling SoapService payloads yields expected result", func(t *testing.T) {
+
+		payload, err := json.Marshal(buildResourcePayload(soapServiceResource, NaisResource{}, class, environment, zone, hostname))
+		payload = bytes.Replace(payload, []byte("\\u0026"), []byte("&"), -1)
+		assert.NoError(t, err)
+		n := len(payload)
+		assert.Equal(t, "{\"alias\":\"resourceAlias\",\"scope\":{\"environmentclass\":\"t\",\"environment\":\"t1000\",\"zone\":\"fss\"},\"type\":\"SoapService\",\"properties\":{\"endpointUrl\":\"https://hostname/myPath\",\"wsdlUrl\":\"http://maven.adeo.no/nexus/service/local/artifact/maven/redirect?a=myArtifactId&e=zip&g=myGroup&r=m2internal&v=2.1\",\"securityToken\":\"LDAP\",\"description\":\"myDescription\"}}", string(payload[:n]))
 	})
 	t.Run("Building RestService ResourcePayload with AllZones returns wider scope", func(t *testing.T) {
 		restResource.AllZones = allZones


### PR DESCRIPTION
To allow exposing a SOAP endpoint without having the service gateway doing its magic we should allow exposing the endpoint as a SoapService in nais.yaml