### PR TITLE
Added quotes on Java options.

### DIFF
--- a/proxyopts/proxyopts.go
+++ b/proxyopts/proxyopts.go
@@ -14,7 +14,7 @@ type javaOption struct {
 type javaOptions []javaOption
 
 func (o javaOption) Format() string {
-	return fmt.Sprintf("-D%s=%s", o.Key, o.Value)
+	return fmt.Sprintf("-D%s='%s'", o.Key, o.Value)
 }
 
 func newJavaOption(key string, value string) javaOption {

--- a/proxyopts/proxyopts_test.go
+++ b/proxyopts/proxyopts_test.go
@@ -12,27 +12,27 @@ var testCases = []struct {
 }{
 	{
 		proxyUrl: "http://foo.bar:1234",
-		Output:   `-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234`,
+		Output:   `-Dhttp.proxyHost='foo.bar' -Dhttps.proxyHost='foo.bar' -Dhttp.proxyPort='1234' -Dhttps.proxyPort='1234'`,
 	},
 	{
 		Output: ``,
 	},
 	{
 		proxyUrl: "http://foo.bar:1234",
-		Output:   `-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234`,
+		Output:   `-Dhttp.proxyHost='foo.bar' -Dhttps.proxyHost='foo.bar' -Dhttp.proxyPort='1234' -Dhttps.proxyPort='1234'`,
 	},
 	{
 		noProxy: "internalhost",
-		Output:  `-Dhttp.nonProxyHosts=internalhost`,
+		Output:  `-Dhttp.nonProxyHosts='internalhost'`,
 	},
 	{
 		noProxy: "host1,host2,.wildcard.local,.local,foo",
-		Output:  `-Dhttp.nonProxyHosts=host1|host2|*.wildcard.local|*.local|foo`,
+		Output:  `-Dhttp.nonProxyHosts='host1|host2|*.wildcard.local|*.local|foo'`,
 	},
 	{
 		proxyUrl: "http://foo.bar:1234",
 		noProxy:  "host1,host2,.wildcard.local,.local,foo",
-		Output:   `-Dhttp.proxyHost=foo.bar -Dhttps.proxyHost=foo.bar -Dhttp.proxyPort=1234 -Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts=host1|host2|*.wildcard.local|*.local|foo`,
+		Output:   `-Dhttp.proxyHost='foo.bar' -Dhttps.proxyHost='foo.bar' -Dhttp.proxyPort='1234' -Dhttps.proxyPort='1234' -Dhttp.nonProxyHosts='host1|host2|*.wildcard.local|*.local|foo'`,
 	},
 	{
 		proxyUrl: "foo.bar:1234",


### PR DESCRIPTION
The pipe (|) symbol in the non-proxy list causes issues in shell since it is not escaped.