### PR TITLE
FIX: Mask fasitPassword and fasitUsername on fmt.print in deploy

### DIFF
--- a/api/naisrequest/deploy_test.go
+++ b/api/naisrequest/deploy_test.go
@@ -1,42 +1,38 @@
 package naisrequest
 
 import (
- 	"encoding/json"
+	"encoding/json"
+	"github.com/nais/naisd/api/naisrequest"
+	"github.com/stretchr/testify/assert"
 	"testing"
-     "github.com/nais/naisd/api/naisrequest"
-     "github.com/stretchr/testify/assert"
- )
+)
 
- func TestStringMethodInDeployNaisRequestShouldHidePasswordAndUsername(t *testing.T) {
-	  deployRequest := naisrequest.Deploy{
-			FasitUsername: "username" ,
-			FasitPassword: "password",
-			Namespace:     "app",
-		}
-		
-		jsonValue,err := json.Marshal(deployRequest.String())
-		if err != nil{
-			panic(err)
-		}
-		assert.Contains(t, string(jsonValue), "***")
-		assert.Contains(t, string(jsonValue), "fasitPassword")
- }
+func TestStringMethodInDeployNaisRequestShouldHidePasswordAndUsername(t *testing.T) {
+	deployRequest := naisrequest.Deploy{
+		FasitUsername: "username",
+		FasitPassword: "password",
+		Namespace:     "app",
+	}
 
+	jsonValue, err := json.Marshal(deployRequest.String())
+	if err != nil {
+		panic(err)
+	}
+	assert.Contains(t, string(jsonValue), "***")
+	assert.Contains(t, string(jsonValue), "fasitPassword")
+}
 
- func TestStringMethodInDeployNaisRequestShouldNotHidePasswordAndUsername(t *testing.T) {
-	  deployRequest := naisrequest.Deploy{
-			FasitUsername: "username" ,
-			FasitPassword: "password",
-			Namespace:     "app",
-		}
-		
-		jsonValue,err := json.Marshal(deployRequest)
-		if err != nil{
-			panic(err)
-		}
-		assert.Contains(t, string(jsonValue), "password")
-		assert.Contains(t, string(jsonValue), "fasitPassword")
- }
+func TestStringMethodInDeployNaisRequestShouldNotHidePasswordAndUsername(t *testing.T) {
+	deployRequest := naisrequest.Deploy{
+		FasitUsername: "username",
+		FasitPassword: "password",
+		Namespace:     "app",
+	}
 
-
-
+	jsonValue, err := json.Marshal(deployRequest)
+	if err != nil {
+		panic(err)
+	}
+	assert.Contains(t, string(jsonValue), "password")
+	assert.Contains(t, string(jsonValue), "fasitPassword")
+}

--- a/api/naisrequest/deploy_test.go
+++ b/api/naisrequest/deploy_test.go
@@ -1,0 +1,23 @@
+package naisrequest
+
+import (
+ 	"encoding/json"
+	"testing"
+     "github.com/nais/naisd/api/naisrequest"
+     "github.com/stretchr/testify/assert"
+ )
+
+ func TestStringMethodInDeployNaisRequestShouldHidePasswordAndUsername(t *testing.T) {
+	  deployRequest := naisrequest.Deploy{
+			FasitUsername: "username" ,
+			FasitPassword: "password",
+			Namespace:     "app",
+		}
+		
+		jsonValue,err := json.Marshal(deployRequest.String())
+		if err != nil{
+			panic(err)
+		}
+		assert.Contains(t, string(jsonValue), "***")
+		assert.Contains(t, string(jsonValue), "fasitPassword")
+ }

--- a/api/naisrequest/deploy_test.go
+++ b/api/naisrequest/deploy_test.go
@@ -21,3 +21,22 @@ import (
 		assert.Contains(t, string(jsonValue), "***")
 		assert.Contains(t, string(jsonValue), "fasitPassword")
  }
+
+
+ func TestStringMethodInDeployNaisRequestShouldNotHidePasswordAndUsername(t *testing.T) {
+	  deployRequest := naisrequest.Deploy{
+			FasitUsername: "username" ,
+			FasitPassword: "password",
+			Namespace:     "app",
+		}
+		
+		jsonValue,err := json.Marshal(deployRequest)
+		if err != nil{
+			panic(err)
+		}
+		assert.Contains(t, string(jsonValue), "password")
+		assert.Contains(t, string(jsonValue), "fasitPassword")
+ }
+
+
+

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -134,7 +134,7 @@ var deployCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		jsonStr, err := json.Marshal(deployRequest)
+		jsonStr, err := json.Marshal(deployRequest.String())
 
 		if err != nil {
 			fmt.Printf("Error while marshalling JSON: %v\n", err)


### PR DESCRIPTION
I have had problems with passwords not being masked when reading print out messages from naisd on deploy.