### PR TITLE
Use out-of-band secret 'naisd-kafka' to configure Kafka credentials

### DIFF
--- a/helm/naisd/templates/deployment.yaml
+++ b/helm/naisd/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
         envFrom:
         - secretRef:
             name: {{ template "naisd.fullname" . }}
+        - secretRef:
+            name: naisd-kafka
         env:
           - name: fasit_url
             value: "{{ .Values.fasitUrl }}"


### PR DESCRIPTION
I found no way to inject _secrets_ using this Helm setup. Here is a way using a pre-defined secret ( set in `nais-yaml`).

Refs #142